### PR TITLE
Update: Wash beneficiaries&&Unit hiding.

### DIFF
--- a/app/scripts/modules/cluster/reports/forms/cluster.project.form.details.js
+++ b/app/scripts/modules/cluster/reports/forms/cluster.project.form.details.js
@@ -343,7 +343,7 @@ angular.module( 'ngm.widget.project.details', [ 'ngm.provider' ])
           var selected = [];
           $beneficiary.beneficiary_type_id = $data;
           if($beneficiary.beneficiary_type_id) {
-            selected = $filter('filter')( $scope.project.lists.beneficiary_types, { beneficiary_type_id: $beneficiary.beneficiary_type_id }, true);
+            selected = $filter('filter')( $scope.project.lists.beneficiary_types, { beneficiary_type_id: $beneficiary.beneficiary_type_id, cluster_id: $beneficiary.cluster_id }, true);
           }
           if ( selected.length ) {
             $beneficiary.beneficiary_type_name = selected[0].beneficiary_type_name;
@@ -406,7 +406,7 @@ angular.module( 'ngm.widget.project.details', [ 'ngm.provider' ])
           var l = $scope.project.definition.target_beneficiaries;
           angular.forEach( l, function(b){
             if( 
-                ( b.cluster_id === 'eiewg' || b.cluster_id === 'fsac' || b.cluster_id === 'wash' ) ||
+                ( b.cluster_id === 'eiewg' || b.cluster_id === 'fsac' ) ||
                 ( b.activity_description_id && 
                 ( b.activity_description_id.indexOf( 'education' ) > -1 ||
                   b.activity_description_id.indexOf( 'training' ) > -1 ||

--- a/app/scripts/modules/cluster/reports/forms/cluster.project.form.report.js
+++ b/app/scripts/modules/cluster/reports/forms/cluster.project.form.report.js
@@ -36,16 +36,16 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
 
       // project
       $scope.project = {
-        
+
         // user
         user: ngmUser.get(),
-        
+
         // app style
         style: config.style,
-        
+
         // project
         definition: config.project,
-        
+
         // report
         report: config.report,
 
@@ -54,13 +54,13 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
 
         // keys to ignore when summing beneficiaries in template ( 2016 )
         skip: [ 'education_sessions', 'training_sessions', 'sessions', 'families', 'notes' ],
-        
+
         // last update
         updatedAt: moment( config.report.updatedAt ).format( 'DD MMMM, YYYY @ h:mm:ss a' ),
-        
+
         // title
         titleFormat: moment( config.report.reporting_period ).format('MMMM, YYYY'),
-        
+
         // lists
         // activity_type: config.project.activity_type,
         activity_descriptions: $scope.activity_descriptions,
@@ -76,11 +76,11 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
           // MPC
           mpc_delivery_types: ngmClusterHelper.getMpcDeliveryTypes()
         },
-        
+
         // templates
         templatesUrl: '/scripts/modules/cluster/views/forms/report/',
         locationsUrl: 'locations.html',
-        beneficiariesUrl: config.report.report_year === 2016 ? 'beneficiaries/2016/beneficiaries.html' : 'beneficiaries/beneficiaries.html',        
+        beneficiariesUrl: config.report.report_year === 2016 ? 'beneficiaries/2016/beneficiaries.html' : 'beneficiaries/beneficiaries.html',
         beneficiariesTrainingUrl: 'beneficiaries/2016/beneficiaries-training.html',
         beneficiariesDefaultUrl: 'beneficiaries/2016/beneficiaries-health-2016.html',
         notesUrl: 'notes.html',
@@ -100,15 +100,15 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
           var sadd = {
             units: 0,
             cash_amount: 0,
-            households: 0, 
-            sessions: 0, 
-            families: 0, 
-            boys: 0, 
-            girls: 0, 
-            men:0, 
-            women:0, 
-            elderly_men:0, 
-            elderly_women:0 
+            households: 0,
+            sessions: 0,
+            families: 0,
+            boys: 0,
+            girls: 0,
+            men:0,
+            women:0,
+            elderly_men:0,
+            elderly_women:0
           };
           $scope.inserted = {
             cluster_id: null,
@@ -175,7 +175,7 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
           if($beneficiary.activity_description_id) {
             selected = $filter('filter')( $scope.project.activity_descriptions, { activity_description_id: $beneficiary.activity_description_id }, true );
             $beneficiary.activity_description_name = selected[0].activity_description_name;
-          } 
+          }
           return selected.length ? selected[0].activity_description_name : 'No Selection!';
         },
 
@@ -184,7 +184,7 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
           var selected = [];
           $beneficiary.mpc_delivery_type_id = $data;
           if($beneficiary.mpc_delivery_type_id) {
-            
+
             // selection
             selected = $filter('filter')( $scope.project.lists.mpc_delivery_types, { mpc_delivery_type_id: $beneficiary.mpc_delivery_type_id }, true );
             if ( selected.length ) {
@@ -197,8 +197,8 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
             }
 
             // no cash! for previous selections
-            if ( $beneficiary.activity_type_id.indexOf( 'cash' ) === -1 && 
-                  $beneficiary.activity_description_id && 
+            if ( $beneficiary.activity_type_id.indexOf( 'cash' ) === -1 &&
+                  $beneficiary.activity_description_id &&
                   ( $beneficiary.activity_description_id.indexOf( 'cash' ) === -1 &&
                     $beneficiary.activity_description_id.indexOf( 'in_kind' ) === -1 ) ) {
               // reset
@@ -247,7 +247,7 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
           }
           return selected.length ? selected[0].delivery_type_name : 'No Selection!';
         },
-        
+
         // display if education/training sessions provided
         showSessions: function( $locationIndex ){
           var display = false;
@@ -270,9 +270,9 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
           var l = $scope.project.report.locations[ $locationIndex ];
           if( l ){
             angular.forEach( l.beneficiaries, function(b){
-            if( 
-                ( b.cluster_id === 'eiewg' || b.cluster_id === 'fsac' || b.cluster_id === 'wash' ) ||
-                ( b.activity_description_id && 
+            if(
+                ( b.cluster_id === 'eiewg' || b.cluster_id === 'fsac' ) ||
+                ( b.activity_description_id &&
                 ( b.activity_description_id.indexOf( 'education' ) > -1 ||
                   b.activity_description_id.indexOf( 'training' ) > -1 ||
                   b.activity_description_id.indexOf( 'cash' ) > -1 ||
@@ -297,7 +297,7 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
           }else{
             $beneficiary.unit_type_id = 'n_a';
             $beneficiary.unit_type_id = 'N/A';
-          }            
+          }
           return selected.length ? selected[0].unit_type_name : 'N/A';
         },
 
@@ -323,8 +323,8 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
           var l = $scope.project.report.locations[ $locationIndex ];
           if( l ){
             angular.forEach( l.beneficiaries, function(b){
-              if( ( b.activity_type_id && b.activity_type_id.indexOf('cash') > -1 ) || 
-                  ( b.activity_description_id && 
+              if( ( b.activity_type_id && b.activity_type_id.indexOf('cash') > -1 ) ||
+                  ( b.activity_description_id &&
                   ( b.activity_description_id.indexOf( 'cash' ) > -1 ||
                     b.activity_description_id.indexOf( 'fsac_in_kind' ) > -1 ) ) ) {
                 display = true;
@@ -368,7 +368,7 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
           var l = $scope.project.report.locations[ $locationIndex ];
           if( l ){
             angular.forEach( l.beneficiaries, function(b){
-                if( ( b.cluster_id !== 'nutrition' || b.activity_type_id === 'nutrition_education_training' ) && 
+                if( ( b.cluster_id !== 'nutrition' || b.activity_type_id === 'nutrition_education_training' ) &&
                   b.activity_type_id !== 'mch' &&
                   b.activity_type_id !== 'vaccination' &&
                   b.activity_description_id !== 'antenatal_care' &&
@@ -389,7 +389,7 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
           var l = $scope.project.report.locations[ $locationIndex ];
           if( l ){
             angular.forEach( l.beneficiaries, function(b){
-              if( b.activity_type_id !== 'vaccination' && 
+              if( b.activity_type_id !== 'vaccination' &&
                   b.activity_description_id !== 'penta_3' &&
                   b.activity_description_id !== 'measles' ){
                 display = true;
@@ -405,14 +405,14 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
           var l = $scope.project.report.locations[ $locationIndex ];
           if( l ){
             angular.forEach( l.beneficiaries, function(b){
-              if( b.cluster_id !== 'eiewg' && 
-                  b.cluster_id !== 'nutrition' && 
-                  b.cluster_id !== 'wash' && 
+              if( b.cluster_id !== 'eiewg' &&
+                  b.cluster_id !== 'nutrition' &&
+                  b.cluster_id !== 'wash' &&
                   b.activity_type_id !== 'mch' &&
                   b.activity_description_id !== 'antenatal_care' &&
                   b.activity_description_id !== 'postnatal_care' &&
                   b.activity_description_id !== 'skilled_birth_attendant' &&
-                  b.activity_type_id !== 'vaccination' && 
+                  b.activity_type_id !== 'vaccination' &&
                   b.activity_description_id !== 'penta_3' &&
                   b.activity_description_id !== 'measles' ){
                 display = true;
@@ -428,14 +428,14 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
           var l = $scope.project.report.locations[ $locationIndex ];
           if( l ){
             angular.forEach( l.beneficiaries, function(b){
-              if( b.cluster_id !== 'eiewg' && 
-                  b.cluster_id !== 'nutrition' && 
-                  b.cluster_id !== 'wash' && 
+              if( b.cluster_id !== 'eiewg' &&
+                  b.cluster_id !== 'nutrition' &&
+                  b.cluster_id !== 'wash' &&
                   b.activity_type_id !== 'mch' &&
                   b.activity_description_id !== 'antenatal_care' &&
                   b.activity_description_id !== 'postnatal_care' &&
                   b.activity_description_id !== 'skilled_birth_attendant' &&
-                  b.activity_type_id !== 'vaccination' && 
+                  b.activity_type_id !== 'vaccination' &&
                   b.activity_description_id !== 'penta_3' &&
                   b.activity_description_id !== 'measles' ){
                 display = true;
@@ -491,7 +491,7 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
           }
           return disabled;
         },
-        
+
         // disable save form
         rowSaveDisabled: function( $data ){
           var disabled = true;
@@ -522,7 +522,7 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
 
         // remove beneficiary
         removeBeneficiary: function() {
-          
+
           // b
           var b = $scope.project.report.locations[ $scope.project.locationIndex ].beneficiaries[ $scope.project.beneficiaryIndex ];
 
@@ -533,8 +533,8 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
             data: {
               id: b.id
             }
-          }          
-          
+          }
+
           // set report
           $http( setBeneficiariesRequest ).success( function( result ){
 
@@ -569,7 +569,7 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
           }, 0 );
         },
 
-        // ennsure all locations contain at least one complete beneficiaries 
+        // ennsure all locations contain at least one complete beneficiaries
         formComplete: function() {
           var beneficiaries = 0;
           var rowComplete = 0;
@@ -587,11 +587,11 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
               }
             }
           });
-          // 
+          //
           if( rowComplete >= beneficiaries ){
             return true;
           } else {
-            return false;  
+            return false;
           }
         },
 
@@ -605,12 +605,12 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
           }
         },
 
-        // save 
+        // save
         save: function( complete, display_modal ){
 
           // if textarea
           $( 'textarea[name="notes"]' ).removeClass( 'ng-untouched' ).addClass( 'ng-touched' );
-          $( 'textarea[name="notes"]' ).removeClass( 'invalid' ).addClass( 'valid' ); 
+          $( 'textarea[name="notes"]' ).removeClass( 'invalid' ).addClass( 'valid' );
 
           // report
           // $scope.project.report.submit = true;
@@ -618,9 +618,9 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
           $scope.project.report.report_submitted = moment().format();
 
           // update project details of report + locations + beneficiaries
-          $scope.project.report = 
+          $scope.project.report =
               ngmClusterHelper.getCleanReport( $scope.project.definition, $scope.project.report );
-          
+
           // msg
           Materialize.toast( 'Processing Report...' , 3000, 'note');
 
@@ -631,8 +631,8 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
             data: {
               report: $scope.project.report
             }
-          }   
-          
+          }
+
           // set report
           $http( setReportRequest ).success( function( report ){
 
@@ -642,21 +642,21 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
             }
 
             if ( !report.err ) {
-              
+
               // updated report
               $scope.project.report = report;
               $scope.project.report.submit = false;
-              
+
               // user msg
               var msg = 'Project Report for  ' + moment( $scope.project.report.reporting_period ).format('MMMM, YYYY') + ' ';
                   msg += complete ? 'Submitted!' : 'Saved!';
-              
+
               // msg
               $timeout(function() { Materialize.toast( msg , 3000, 'success'); }, 600 );
-              
+
               // set trigger
               $('.modal-trigger').leanModal();
-              
+
               // Re-direct to summary
               if ( $scope.project.report.report_status !== 'complete' ) {
 
@@ -685,4 +685,3 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
   }
 
 ]);
-

--- a/app/scripts/modules/cluster/services/ngmClusterHelper.js
+++ b/app/scripts/modules/cluster/services/ngmClusterHelper.js
@@ -9,7 +9,7 @@ angular.module( 'ngmReportHub' )
 	.factory( 'ngmClusterHelper', [ '$location', '$q', '$http', '$filter', '$timeout', 'ngmAuth', function( $location, $q, $http, $filter, $timeout, ngmAuth ) {
 
 		return {
-			
+
 			// update material_select
 			updateSelect: function(){
         $timeout(function(){ $( 'select' ).material_select(); }, 0 );
@@ -42,7 +42,7 @@ angular.module( 'ngmReportHub' )
 
         // set hrp code
         project.project_hrp_code = this.getProjectHrpCode( project );
-        
+
         // remove id of ngmUser to avoid conflict with new project
         delete project.id;
 
@@ -57,7 +57,7 @@ angular.module( 'ngmReportHub' )
         // report
         var report = project.admin0pcode === 'AF' ? '-OTH-' : '-HRP-';
 
-        // return project code 
+        // return project code
         return project.admin0name.toUpperCase().substring(0, 3) + report +
                         moment().year() + '-' +
                         project.cluster.toUpperCase().substring(0, 3) + '-' +
@@ -66,7 +66,7 @@ angular.module( 'ngmReportHub' )
 
       // get lists for cluster reporting
       setClusterLists: function( user ) {
-      
+
         // requests
         var requests = {
 
@@ -114,7 +114,7 @@ angular.module( 'ngmReportHub' )
 
         }
 
-        // get all lists 
+        // get all lists
         if ( !localStorage.getObject( 'lists' ) ) {
 
           // admin1, admin2, activities holders
@@ -132,12 +132,12 @@ angular.module( 'ngmReportHub' )
           localStorage.setObject( 'lists', lists );
 
           // send request
-          $q.all([ 
+          $q.all([
             $http( requests.getAdmin1List ),
             $http( requests.getAdmin2List ),
             $http( requests.getAdmin3List ),
-            $http( requests.getActivities ), 
-            $http( requests.getDonors ), 
+            $http( requests.getActivities ),
+            $http( requests.getDonors ),
             $http( requests.getIndicators ),
             $http( requests.getStockItems ) ] ).then( function( results ){
 
@@ -196,7 +196,7 @@ angular.module( 'ngmReportHub' )
           delivery_type_id: 'service',
           delivery_type_name: 'Existing Beneficiaries'
         }];
-      },      
+      },
 
       // mpc delivery
       getMpcDeliveryTypes: function() {
@@ -204,7 +204,7 @@ angular.module( 'ngmReportHub' )
         // food_for_asset_in_kind
         // food_for_asset_cbt
         // food_for_training_in_kind
-        // food_for_training_cbt        
+        // food_for_training_cbt
 
         var types = [{
             activity_description_id: [ 'fsac_cash', 'fsac_multi_purpose_cash', 'esnfi_multi_purpose_cash', 'cvwg_multi_purpose_cash', 'cash_nfi', 'cash_winterization', 'cash_rent', 'cash_shelter_repair', 'shelter_construction_cash_permanent', 'shelter_construction_cash_transitional' ],
@@ -247,7 +247,7 @@ angular.module( 'ngmReportHub' )
         return types;
       },
 
-      // get list 
+      // get list
       getTransfers: function( length ){
         var trasnfers = [];
         for( var i=1; i<=length; i++ ){
@@ -322,7 +322,7 @@ angular.module( 'ngmReportHub' )
           activities = this.filterDuplicates( activities, 'activity_type_id' );
         }
 
-        // return 
+        // return
         return activities;
 
       },
@@ -331,7 +331,7 @@ angular.module( 'ngmReportHub' )
 			getDonors: function( cluster_id ) {
 
         // get from list
-        var donors = $filter( 'filter' )( localStorage.getObject( 'lists' ).donorsList, 
+        var donors = $filter( 'filter' )( localStorage.getObject( 'lists' ).donorsList,
                           { cluster_id: cluster_id }, true );
 
         // if no list use default
@@ -566,7 +566,7 @@ angular.module( 'ngmReportHub' )
         // for each beneficiaries from list
         angular.forEach( list, function( d, i ){
           // filter out selected types
-          beneficiaries = 
+          beneficiaries =
               $filter( 'filter' )( beneficiaries, { beneficiary_type: '!' + d.beneficiary_type } );
         });
 
@@ -585,7 +585,7 @@ angular.module( 'ngmReportHub' )
 
         // admin ET
         if ( admin0pcode === 'ET' ) {
-          
+
           // beneficiaries
           beneficiaries = [{
             cluster_id: [ 'cvwg', 'eiewg', 'esnfi', 'fsac', 'health', 'nutrition', 'protection', 'rnr_chapter', 'wash' ],
@@ -638,11 +638,16 @@ angular.module( 'ngmReportHub' )
             beneficiary_type_id: 'conflict_affected',
             beneficiary_type_name: 'Conflict Affected'
           },{
-            cluster_id: [ 'cvwg', 'esnfi', 'fsac', 'health', 'protection', 'wash' ],
+            cluster_id: [ 'cvwg', 'esnfi', 'fsac', 'health', 'protection' ],
             category_type_id: [ 'category_a' ],
             beneficiary_type_id: 'idp_conflict',
             beneficiary_type_name: 'Conflict IDPs'
           },{
+						cluster_id: [ 'wash' ],
+            category_type_id: [ 'category_a' ],
+            beneficiary_type_id: 'idp_conflict',
+            beneficiary_type_name: 'Conflict IDPs (Recent)'
+					},{
           //   cluster_id: [ 'cvwg', 'esnfi', 'fsac', 'health', 'protection', 'wash' ],
           //   category_type_id: [ 'category_a' ],
           //   beneficiary_type_id: 'idp_conflict_natural_disaster',
@@ -657,7 +662,7 @@ angular.module( 'ngmReportHub' )
             cluster_id: [ 'wash' ],
             category_type_id: [ 'category_b' ],
             beneficiary_type_id: 'idp_conflict',
-            beneficiary_type_name: 'Conflict IDPs'
+            beneficiary_type_name: 'Conflict IDPs (Recent)'
           },{
           //   cluster_id: [ 'wash' ],
           //   category_type_id: [ 'category_b' ],
@@ -686,11 +691,16 @@ angular.module( 'ngmReportHub' )
             beneficiary_type_id: 'conflict_affected',
             beneficiary_type_name: 'Conflict Affected'
           },{
-            cluster_id: [ 'cvwg', 'esnfi', 'fsac', 'health', 'nutrition', 'protection', 'wash' ],
+            cluster_id: [ 'cvwg', 'esnfi', 'fsac', 'health', 'nutrition', 'protection' ],
             category_type_id: [ 'category_d' ],
             beneficiary_type_id: 'idp_conflict',
             beneficiary_type_name: 'Conflict IDPs'
           },{
+						cluster_id: [ 'wash' ],
+            category_type_id: [ 'category_d' ],
+            beneficiary_type_id: 'idp_conflict',
+            beneficiary_type_name: 'Conflict IDPs (Recent)'
+					},{
           //   cluster_id: [ 'cvwg', 'esnfi', 'fsac', 'health', 'nutrition', 'protection', 'wash' ],
           //   category_type_id: [ 'category_d' ],
           //   beneficiary_type_id: 'idp_conflict_natural_disaster',
@@ -732,7 +742,7 @@ angular.module( 'ngmReportHub' )
             category_type_id: [ 'category_c' ],
             beneficiary_type_id: 'natural_disaster_affected',
             beneficiary_type_name: 'Natural Disaster Affected'
-          },{   
+          },{
             // CAT D) Natural Disaster
             cluster_id: [ 'cvwg', 'esnfi', 'fsac', 'health', 'nutrition', 'protection', 'wash' ],
             category_type_id: [ 'category_d' ],
@@ -745,7 +755,7 @@ angular.module( 'ngmReportHub' )
             beneficiary_type_name: 'Natural Disaster Affected'
           },{
 
-            
+
             // FSAC
 
             // CAT A), CAT B), Conflict, Natural Disaster
@@ -789,11 +799,16 @@ angular.module( 'ngmReportHub' )
             // Refugees, IDPs
 
             // CAT A), Cat B), Cat C), Protracted IDPs
-            cluster_id: [ 'cvwg', 'esnfi', 'fsac', 'health', 'nutrition', 'protection', 'wash' ],
+            cluster_id: [ 'cvwg', 'esnfi', 'fsac', 'health', 'nutrition', 'protection' ],
             category_type_id: [ 'category_a', 'category_b', 'category_c' ],
             beneficiary_type_id: 'idp_protracted',
             beneficiary_type_name: 'Protracted IDPs'
           },{
+						cluster_id: [ 'wash' ],
+            category_type_id: [ 'category_a', 'category_b' ],
+            beneficiary_type_id: 'idp_protracted',
+            beneficiary_type_name: 'Conflict IDPs (Prolonged)'
+					},{
             // CAT A)
             cluster_id: [ 'cvwg', 'esnfi', 'fsac', 'health', 'protection', 'wash' ],
             category_type_id: [ 'category_a' ],
@@ -856,7 +871,7 @@ angular.module( 'ngmReportHub' )
 
 
             // EiEWG
-            
+
             // CAT A), Refugees & Returnees
             cluster_id: [ 'eiewg' ],
             category_type_id: [ 'category_a', 'category_d' ],
@@ -935,7 +950,7 @@ angular.module( 'ngmReportHub' )
 
 
             // Access to services
-            
+
             // CAT B)
 
             cluster_id: [ 'health' ],
@@ -1000,30 +1015,30 @@ angular.module( 'ngmReportHub' )
 
 			},
 
-      // get facility implementation 
+      // get facility implementation
       getFacilityImplementation: function( cluster_id ){
         var facility_implementation = [];
         if ( cluster_id === 'eiewg'  ) {
-          facility_implementation = [{ 
-            facility_implementation_id: 'formal', 
-            facility_implementation_name: 'Formal' 
-          },{ 
-            facility_implementation_id: 'informal', 
-            facility_implementation_name: 'Informal' 
+          facility_implementation = [{
+            facility_implementation_id: 'formal',
+            facility_implementation_name: 'Formal'
+          },{
+            facility_implementation_id: 'informal',
+            facility_implementation_name: 'Informal'
           }]
         } else {
-          facility_implementation = [{ 
-            facility_implementation_id: 'standalone', 
-            facility_implementation_name: 'Standalone Facility' 
-          },{ 
-            facility_implementation_id: 'embedded', 
-            facility_implementation_name: 'Embedded Facility' 
-          },{ 
-            facility_implementation_id: 'community', 
-            facility_implementation_name: 'Community Based' 
-          },{ 
-            facility_implementation_id: 'multiple', 
-            facility_implementation_name: 'Multiple Locations' 
+          facility_implementation = [{
+            facility_implementation_id: 'standalone',
+            facility_implementation_name: 'Standalone Facility'
+          },{
+            facility_implementation_id: 'embedded',
+            facility_implementation_name: 'Embedded Facility'
+          },{
+            facility_implementation_id: 'community',
+            facility_implementation_name: 'Community Based'
+          },{
+            facility_implementation_id: 'multiple',
+            facility_implementation_name: 'Multiple Locations'
           }]
         }
         return facility_implementation;
@@ -1167,7 +1182,7 @@ angular.module( 'ngmReportHub' )
       getSumBeneficiaries: function( locations ) {
 
         var $this = this;
-        
+
         // sum beneficiary.sum
         angular.forEach( locations, function( l, i ){
           angular.forEach( l.beneficiaries, function( b, j ){
@@ -1190,7 +1205,7 @@ angular.module( 'ngmReportHub' )
 
       // update activities for an object ( update )
       updateActivities: function( project, update ){
-        
+
         // update activity_type / activity_description
         update.project_title = project.project_title;
         update.activity_type = project.activity_type;
@@ -1203,7 +1218,7 @@ angular.module( 'ngmReportHub' )
 
       // get processed warehouse location
       getCleanWarehouseLocation: function( user, organization, warehouse ){
-        
+
         // merge
         var warehouse = angular.merge({}, organization, warehouse, warehouse.admin2, warehouse.admin3, warehouse.facility_type);
 
@@ -1226,7 +1241,7 @@ angular.module( 'ngmReportHub' )
 
       // get processed stock location
       getCleanStocks: function( report, location, stocks ){
-        
+
         // merge
         var stock = angular.merge( {}, stocks, report, location );
 
@@ -1234,7 +1249,7 @@ angular.module( 'ngmReportHub' )
         delete stock.id;
         delete stock.stocks;
         delete stock.stocklocations;
-        
+
         // default stock
         stock.report_id = stock.report_id.id;
         stock.number_in_stock = 0;
@@ -1326,10 +1341,10 @@ angular.module( 'ngmReportHub' )
           delete locations[i].activity_type;
           delete locations[i].beneficiary_type;
           locations[i] = angular.merge( {}, d, p );
-          // set facility_lng, facility_lat 
+          // set facility_lng, facility_lat
             // this is propigated through the entire datasets
           if ( !locations[i].facility_lng && !locations[i].facility_lat ) {
-            // set admin3 or admin2 
+            // set admin3 or admin2
             locations[i].facility_lng = locations[i].admin3lng ? locations[i].admin3lng : locations[i].admin2lng;
             locations[i].facility_lat = locations[i].admin3lat ? locations[i].admin3lat : locations[i].admin2lat;
           }
@@ -1342,7 +1357,7 @@ angular.module( 'ngmReportHub' )
 
       // update entire report with project details (dont ask)
       getCleanReport: function( project, report ) {
-        
+
         // copy to p
         var p = angular.copy( project );
         var r = angular.copy( report );
@@ -1364,7 +1379,7 @@ angular.module( 'ngmReportHub' )
         delete r.project_donor;
         delete r.strategic_objectives;
 
-        // merge 
+        // merge
         report = angular.merge( {}, r, p );
 
         // locations
@@ -1375,7 +1390,7 @@ angular.module( 'ngmReportHub' )
           delete r.id;
           delete p.admin1pcode;
           delete p.admin2pcode;
-          delete p.admin3pcode;          
+          delete p.admin3pcode;
           delete r.admin1pcode;
           delete r.admin2pcode;
           delete r.admin3pcode;
@@ -1469,7 +1484,7 @@ angular.module( 'ngmReportHub' )
 
 			},
 
-      // get objectives by cluster 
+      // get objectives by cluster
       getStrategicObjectives: function(){
 
         var strategic_objectives = {
@@ -1668,7 +1683,7 @@ angular.module( 'ngmReportHub' )
       filterDuplicates: function( items, filterOn ){
 
           // vars
-          var hashCheck = {}, 
+          var hashCheck = {},
               newItems = [];
 
           // comparison fn
@@ -1678,7 +1693,7 @@ angular.module( 'ngmReportHub' )
             } else {
               return item;
             }
-          };          
+          };
 
           // filter unique
           angular.forEach( items, function ( item ) {
@@ -1694,7 +1709,7 @@ angular.module( 'ngmReportHub' )
               newItems.push( item );
             }
           });
-          
+
           return newItems;
 
       }

--- a/app/scripts/modules/cluster/views/forms/details/target-beneficiaries/target-beneficiaries.html
+++ b/app/scripts/modules/cluster/views/forms/details/target-beneficiaries/target-beneficiaries.html
@@ -3,7 +3,7 @@
 	<div class="col s12 m12 l12">
 		<div class="card">
 			<ul class="collection with-header">
-				
+
 				<li class="collection-header blue lighten-4">
 					<h5 class="report-work-title">
 <!-- 						<i class="material-icons left">group</i><span class="beneficiary-count">{{ project.definition.target_beneficiaries | sumArrayByKeys:project.indicators:project.skip | number }}</span> Target Population -->
@@ -79,7 +79,7 @@
 							          {{ project.showDescription($data, beneficiary) }}
 							        </span>
 							      </td>
-							      
+
 							      <td ng-show="project.showCash()">
 							        <span e-form="rowform"
 							              e-name="mpc_delivery_type_id"
@@ -149,19 +149,34 @@
 							        			editable-number="beneficiary.units"
 							        			e-min="0"
 							        			e-ng-change="project.updateInput($index, 'units', $data )"
-						              	e-ng-disabled="!project.showUnits()"
+						              	e-ng-disabled="
+															!project.showUnits() ||
+															!beneficiary.activity_description_id ||
+															( project.definition.cluster_id === 'wash' &&
+																beneficiary.activity_description_id.indexOf('education') === -1 &&
+																beneficiary.activity_description_id.indexOf('training') === -1 &&
+																beneficiary.activity_description_id.indexOf('cash') === -1 &&
+																beneficiary.activity_description_id.indexOf('in_kind') === -1 )"
 							        			e-required>
 							          {{ beneficiary.units }}
 							        </span>
 							      </td>
-								     
+
 								    <!-- unit type -->
 	 								  <td ng-show="project.showUnits()">
 							        <span e-form="rowform"
 							        			e-name="unit_type_id"
 							        			editable-select="beneficiary.unit_type_id"
 														e-placeholder="Select..."
-							        			e-ng-options="a.unit_type_id as a.unit_type_name for a in project.lists.units">
+							        			e-ng-options="a.unit_type_id as a.unit_type_name for a in project.lists.units"
+														e-ng-disabled="
+															!project.showUnits() ||
+															!beneficiary.activity_description_id ||
+															( project.definition.cluster_id === 'wash' &&
+																beneficiary.activity_description_id.indexOf('education') === -1 &&
+																beneficiary.activity_description_id.indexOf('training') === -1 &&
+																beneficiary.activity_description_id.indexOf('cash') === -1 &&
+																beneficiary.activity_description_id.indexOf('in_kind') === -1 )">
 							          {{ project.showUnitTypes($data, beneficiary) }}
 							        </span>
 							      </td>
@@ -189,7 +204,7 @@
 							        			editable-number="beneficiary.households"
 							        			e-min="0"
 							        			e-ng-change="project.updateInput( $index, 'households', $data )"
-							        			e-ng-disabled="!project.showHouseholds()"	        			
+							        			e-ng-disabled="!project.showHouseholds()"
 							        			e-required>
 							          {{ beneficiary.households }}
 							        </span>
@@ -209,7 +224,7 @@
 							      </td>
 							      <td>
 							        <!-- editable number -->
-							        <span e-form="rowform" 
+							        <span e-form="rowform"
 							        			e-name="boys"
 							        			editable-number="beneficiary.boys"
 							        			e-min="0"
@@ -236,7 +251,7 @@
 							        			editable-number="beneficiary.men"
 							        			e-min="0"
 							        			e-ng-change="project.updateInput($index, 'men', $data )"
-							        			e-ng-disabled="( beneficiary.cluster_id === 'nutrition' && 
+							        			e-ng-disabled="( beneficiary.cluster_id === 'nutrition' &&
 							        							beneficiary.activity_type_id !== 'nutrition_education_training' ) ||
 							        							beneficiary.activity_type_id === 'mch' ||
 							        							beneficiary.activity_type_id === 'vaccination' ||
@@ -304,13 +319,13 @@
 							          {{ beneficiary.elderly_women }}
 							        </span>
 							      </td>
-							      
+
 							      <td style="white-space: nowrap" ng-show="project.definition.project_status !== 'complete'" >
 							        <!-- form -->
 							        <form editable-form name="rowform" ng-show="rowform.$visible" onbeforesave="project.saveBeneficiary()" class="form-buttons form-inline" shown="inserted == beneficiary">
-							          <button 
+							          <button
 							          		title="Save" type="submit" class="btn waves-effect waves-light save"
-							          		ng-if="rowform.$visible && !project.newProject" 
+							          		ng-if="rowform.$visible && !project.newProject"
 							          		ng-disabled="
 							                  	( ( !project.project_details_valid() ) ||
 							                    ( !project.activity_type_valid() ) ||
@@ -345,9 +360,9 @@
 							                    ( !project.submit ) )">
 							          	<i class="material-icons">delete</i>
 							          </button>
-							        </div>  
+							        </div>
 							      </td>
-							      
+
 							    </tr>
 							  </table>
 

--- a/app/scripts/modules/cluster/views/forms/report/beneficiaries/beneficiaries.html
+++ b/app/scripts/modules/cluster/views/forms/report/beneficiaries/beneficiaries.html
@@ -1,6 +1,6 @@
 
 <style>
-  
+
   .collection.with-header .collection-item.avatar{
     padding-left: 51 !important;
   }
@@ -26,7 +26,7 @@
       <td ng-if="project.showMen( $locationIndex )">Men</td>
       <td ng-if="project.showWomen( $locationIndex )">Women</td>
       <td ng-if="false">Eld. Men</td>
-      <td ng-if="false">Eld. Women</td>      
+      <td ng-if="false">Eld. Women</td>
       <td ng-if="project.report.report_status !== 'complete'">Edit</td>
     </tr>
     <tr ng-repeat="beneficiary in project.report.locations[$locationIndex].beneficiaries track by $index">
@@ -71,7 +71,7 @@
         <span e-form="rowform"
               e-name="category_type_id"
               editable-select="beneficiary.category_type_id"
-              e-placeholder="Select..." 
+              e-placeholder="Select..."
               e-ng-options="b.category_type_id as b.category_type_name for b in project.category_types | filter:{ cluster_id: beneficiary.cluster_id }"
               e-ng-disabled="!beneficiary.activity_description_id">
           {{ project.showCategory($data, beneficiary) }}
@@ -143,11 +143,12 @@
               e-min="0"
               e-ng-change="project.updateInput( $locationIndex, $index, 'units', $data )"
               e-ng-disabled="
-                ( b.cluster_id !== 'eiewg' && b.cluster_id !== 'fsac' && b.cluster_id !== 'wash' ) &&
-                ( b.activity_description_id && 
-                ( b.activity_description_id.indexOf( 'education' ) > -1 &&
-                  b.activity_description_id.indexOf( 'training' ) > -1 &&
-                  b.activity_description_id.indexOf('cash') > -1 ) )"
+                  !beneficiary.activity_description_id ||
+                  ( project.definition.cluster_id === 'wash' &&
+                  beneficiary.activity_description_id.indexOf('education') === -1 &&
+                  beneficiary.activity_description_id.indexOf('training') === -1 &&
+                  beneficiary.activity_description_id.indexOf('cash') === -1 &&
+                  beneficiary.activity_description_id.indexOf('in_kind') === -1 )"
               e-required>
           {{ beneficiary.units }}
         </span>
@@ -157,7 +158,14 @@
               e-name="unit_type_id"
               editable-select="beneficiary.unit_type_id"
               e-placeholder="Select..."
-              e-ng-options="a.unit_type_id as a.unit_type_name for a in project.lists.units">
+              e-ng-options="a.unit_type_id as a.unit_type_name for a in project.lists.units"
+              e-ng-disabled="
+                !beneficiary.activity_description_id ||
+                ( project.definition.cluster_id === 'wash' &&
+                beneficiary.activity_description_id.indexOf('education') === -1 &&
+                beneficiary.activity_description_id.indexOf('training') === -1 &&
+                beneficiary.activity_description_id.indexOf('cash') === -1 &&
+                beneficiary.activity_description_id.indexOf('in_kind') === -1 )">
           {{ project.showUnitTypes($data, beneficiary) }}
         </span>
       </td>
@@ -219,7 +227,7 @@
       <td>
         <!-- editable number -->
         <span e-form="rowform"
-              e-name="girls" 
+              e-name="girls"
               editable-number="beneficiary.girls"
               e-min="0"
               e-ng-change="project.updateInput( $locationIndex, $index, 'girls', $data )"
@@ -253,8 +261,8 @@
         <span e-form="rowform"
               e-name="women"
               editable-number="beneficiary.women"
-              e-min="0" 
-              e-ng-change="project.updateInput( $locationIndex, $index, 'women', $data )" 
+              e-min="0"
+              e-ng-change="project.updateInput( $locationIndex, $index, 'women', $data )"
               e-ng-disabled="
                       beneficiary.activity_type_id === 'vaccination' ||
                       beneficiary.activity_description_id === 'penta_3' ||
@@ -268,8 +276,8 @@
         <span e-form="rowform"
               e-name="elderly_men"
               editable-number="beneficiary.elderly_men"
-              e-min="0" 
-              e-ng-change="project.updateInput( $locationIndex, $index, 'elderly_men', $data )" 
+              e-min="0"
+              e-ng-change="project.updateInput( $locationIndex, $index, 'elderly_men', $data )"
               e-ng-disabled="beneficiary.cluster_id === 'eiewg' ||
                       beneficiary.cluster_id === 'nutrition' ||
                       beneficiary.cluster_id === 'wash' ||
@@ -289,8 +297,8 @@
         <span e-form="rowform"
               e-name="elderly_women"
               editable-number="beneficiary.elderly_women"
-              e-min="0" 
-              e-ng-change="project.updateInput( $locationIndex, $index, 'elderly_women', $data )" 
+              e-min="0"
+              e-ng-change="project.updateInput( $locationIndex, $index, 'elderly_women', $data )"
               e-ng-disabled="beneficiary.cluster_id === 'eiewg' ||
                       beneficiary.cluster_id === 'nutrition' ||
                       beneficiary.cluster_id === 'wash' ||
@@ -304,8 +312,8 @@
               e-required>
           {{ beneficiary.elderly_women }}
         </span>
-      </td>  
-      
+      </td>
+
       <td style="white-space: nowrap" ng-show="project.report.report_status !== 'complete'">
         <!-- form -->
         <form editable-form name="rowform" onshow="project.keydownSaveForm()" ng-show="rowform.$visible" onbeforesave="project.save( false, false )" class="form-buttons form-inline" shown="inserted === beneficiary">
@@ -324,7 +332,7 @@
               ng-disabled="!project.formComplete()">
           	<i class="material-icons">delete</i>
           </div>
-        </div>  
+        </div>
       </td>
 
     </tr>


### PR DESCRIPTION
[Rename beneficiary and hide Amount and Units for Wash](https://github.com/pfitzpaddy/ngm-reportDesk/issues/10)

By renaming for wash  "beneficiary_type_name" from  "Conflict IDPs" to "Conflict IDPs (Recent)" and "Protracted IDPs" to "Conflict IDPs (Prolonged )"
There is issue however with  beneficiary_type field in intercluster scenario when choosing the same "beneficiary_type_id" : "idp_conflict" in multiple clusters 

"beneficiary_type" : [
        {
            "beneficiary_type_id" : "idp_conflict", 
            "beneficiary_type_name" : "Conflict IDPs"
        }
    ], 

There will be no consistency with beneficiary_type_name as no cluster marker available, and poses the same difficulties in renaming as we would not know if which cluster it would be in intercluster.

Maybe renaming globally in such case would more reliant but not flexible.

PS with a bunch of white spaces removes