### PR TITLE
Experimental feature default beneficiaries

### DIFF
--- a/app/scripts/modules/cluster/reports/controllers/cluster.project.report.js
+++ b/app/scripts/modules/cluster/reports/controllers/cluster.project.report.js
@@ -151,102 +151,103 @@ angular.module('ngmReportHub')
 						// no functnlty to not show if user deletes in the same month
 						// maybe better to delete it on backend
 						// could be excessive and bug prone
-					} else {
-						// for report location
-						var report_cleaned_beneficiaries_array = [];
-						// comparation lines
-						angular.forEach(l.beneficiaries, function (b, i) {
-
-							var existing_target_benf = {
-								cluster_id: b.cluster_id,
-								cluster: b.cluster,
-								category_type_id: b.category_type_id,
-								category_type_name: b.category_type_name,
-								beneficiary_type_id: b.beneficiary_type_id,
-								beneficiary_type_name: b.beneficiary_type_name,
-								activity_type_id: b.activity_type_id,
-								activity_type_name: b.activity_type_name,
-								activity_description_id: b.activity_description_id,
-								activity_description_name: b.activity_description_name,
-								delivery_type_id: b.delivery_type_id,
-								delivery_type_name: b.delivery_type_name,
-							};
-
-							if (b.mpc_delivery_type_id&&b.mpc_delivery_type_name){
-								var add_mpc = {
-									mpc_delivery_type_id: b.mpc_delivery_type_id,
-									mpc_delivery_type_name: b.mpc_delivery_type_id
-								}
-								angular.merge(existing_target_benf, add_mpc);
-							};
-
-							report_cleaned_beneficiaries_array.push(existing_target_benf);
-						})
-
-						// check each project target beneficiary with reports
-						angular.forEach(project.target_beneficiaries, function (p, i) {
-							var target_benf = {
-								cluster_id: p.cluster_id,
-								cluster: p.cluster,
-								category_type_id: p.category_type_id,
-								category_type_name: p.category_type_name,
-								beneficiary_type_id: p.beneficiary_type_id,
-								beneficiary_type_name: p.beneficiary_type_name,
-								activity_type_id: p.activity_type_id,
-								activity_type_name: p.activity_type_name,
-								activity_description_id: p.activity_description_id,
-								activity_description_name: p.activity_description_name,
-								delivery_type_id: p.delivery_type_id,
-								delivery_type_name: p.delivery_type_name,
-							};
-
-							if (p.mpc_delivery_type_id&&p.mpc_delivery_type_name){
-								var add_mpc = {
-									mpc_delivery_type_id: p.mpc_delivery_type_id,
-									mpc_delivery_type_name: p.mpc_delivery_type_id
-								}
-								angular.merge(target_benf, add_mpc);
-							};
-
-							var sadd = {
-								units: 0,
-								cash_amount: 0,
-								households: 0,
-								sessions: 0,
-								families: 0,
-								boys: 0,
-								girls: 0,
-								men: 0,
-								women: 0,
-								elderly_men: 0,
-								elderly_women: 0
-							};
-
-							var addon = {
-								transfer_type_id: 0,
-								transfer_type_value: 0,
-								default_beneficiary: true,
-							};
-
-							var eq = 0;
-							var flag = true;
-
-							// find if target beneficiary does not exists in report location
-							angular.forEach(report_cleaned_beneficiaries_array, function (rb, i) {
-								if (flag && angular.equals(target_benf, rb))
-								{eq += 1;
-									flag = false;}
-							})
-
-							if (!eq) {
-								var target_benf_copy = angular.copy(target_benf);
-								angular.merge(target_benf_copy, sadd, addon);
-								l.beneficiaries.push(target_benf_copy);
-
-							}
-
-						})
 					}
+					// else {
+					// 	// for report location
+					// 	var report_cleaned_beneficiaries_array = [];
+					// 	// comparation lines
+					// 	angular.forEach(l.beneficiaries, function (b, i) {
+
+					// 		var existing_target_benf = {
+					// 			cluster_id: b.cluster_id,
+					// 			cluster: b.cluster,
+					// 			category_type_id: b.category_type_id,
+					// 			category_type_name: b.category_type_name,
+					// 			beneficiary_type_id: b.beneficiary_type_id,
+					// 			beneficiary_type_name: b.beneficiary_type_name,
+					// 			activity_type_id: b.activity_type_id,
+					// 			activity_type_name: b.activity_type_name,
+					// 			activity_description_id: b.activity_description_id,
+					// 			activity_description_name: b.activity_description_name,
+					// 			delivery_type_id: b.delivery_type_id,
+					// 			delivery_type_name: b.delivery_type_name,
+					// 		};
+
+					// 		if (b.mpc_delivery_type_id&&b.mpc_delivery_type_name){
+					// 			var add_mpc = {
+					// 				mpc_delivery_type_id: b.mpc_delivery_type_id,
+					// 				mpc_delivery_type_name: b.mpc_delivery_type_id
+					// 			}
+					// 			angular.merge(existing_target_benf, add_mpc);
+					// 		};
+
+					// 		report_cleaned_beneficiaries_array.push(existing_target_benf);
+					// 	})
+
+					// 	// check each project target beneficiary with reports
+					// 	angular.forEach(project.target_beneficiaries, function (p, i) {
+					// 		var target_benf = {
+					// 			cluster_id: p.cluster_id,
+					// 			cluster: p.cluster,
+					// 			category_type_id: p.category_type_id,
+					// 			category_type_name: p.category_type_name,
+					// 			beneficiary_type_id: p.beneficiary_type_id,
+					// 			beneficiary_type_name: p.beneficiary_type_name,
+					// 			activity_type_id: p.activity_type_id,
+					// 			activity_type_name: p.activity_type_name,
+					// 			activity_description_id: p.activity_description_id,
+					// 			activity_description_name: p.activity_description_name,
+					// 			delivery_type_id: p.delivery_type_id,
+					// 			delivery_type_name: p.delivery_type_name,
+					// 		};
+
+					// 		if (p.mpc_delivery_type_id&&p.mpc_delivery_type_name){
+					// 			var add_mpc = {
+					// 				mpc_delivery_type_id: p.mpc_delivery_type_id,
+					// 				mpc_delivery_type_name: p.mpc_delivery_type_id
+					// 			}
+					// 			angular.merge(target_benf, add_mpc);
+					// 		};
+
+					// 		var sadd = {
+					// 			units: 0,
+					// 			cash_amount: 0,
+					// 			households: 0,
+					// 			sessions: 0,
+					// 			families: 0,
+					// 			boys: 0,
+					// 			girls: 0,
+					// 			men: 0,
+					// 			women: 0,
+					// 			elderly_men: 0,
+					// 			elderly_women: 0
+					// 		};
+
+					// 		var addon = {
+					// 			transfer_type_id: 0,
+					// 			transfer_type_value: 0,
+					// 			default_beneficiary: true,
+					// 		};
+
+					// 		var eq = 0;
+					// 		var flag = true;
+
+					// 		// find if target beneficiary does not exists in report location
+					// 		angular.forEach(report_cleaned_beneficiaries_array, function (rb, i) {
+					// 			if (flag && angular.equals(target_benf, rb))
+					// 			{eq += 1;
+					// 				flag = false;}
+					// 		})
+
+					// 		if (!eq) {
+					// 			var target_benf_copy = angular.copy(target_benf);
+					// 			angular.merge(target_benf_copy, sadd, addon);
+					// 			l.beneficiaries.push(target_benf_copy);
+
+					// 		}
+
+					// 	})
+					// }
 				})
 			},
 

--- a/app/scripts/modules/cluster/reports/controllers/cluster.project.report.js
+++ b/app/scripts/modules/cluster/reports/controllers/cluster.project.report.js
@@ -7,13 +7,13 @@
  */
 angular.module('ngmReportHub')
 	.controller('ClusterProjectReportCtrl', [
-			'$scope', 
-			'$route', 
-			'$q', 
-			'$http', 
-			'$location', 
+			'$scope',
+			'$route',
+			'$q',
+			'$http',
+			'$location',
 			'$anchorScroll',
-			'$timeout', 
+			'$timeout',
 			'ngmAuth',
 			'ngmData',
 			'ngmUser',
@@ -31,7 +31,7 @@ angular.module('ngmReportHub')
 
 		// empty Project
 		$scope.report = {
-			
+
 			// parent
 			ngm: $scope.$parent.ngm,
 
@@ -40,7 +40,7 @@ angular.module('ngmReportHub')
 
 			// placeholder
 			definition: {},
-			
+
 			// current user
 			user: ngmUser.get(),
 
@@ -65,6 +65,193 @@ angular.module('ngmReportHub')
 				}
 			}),
 
+			// add beneficiary, spin off of addBeneficiary fnc
+			addDefaultBeneficiaries: function (report, project) {
+
+				// cleaned project beneficiaries
+				var target_beneficiaries_array = [];
+
+				angular.forEach(project.target_beneficiaries, function (p, i) {
+
+					// null fields
+					var sadd = {
+						units: 0,
+						cash_amount: 0,
+						households: 0,
+						sessions: 0,
+						families: 0,
+						boys: 0,
+						girls: 0,
+						men: 0,
+						women: 0,
+						elderly_men: 0,
+						elderly_women: 0
+					};
+
+					// for merge, if missing fields
+					var inserted = {
+						cluster_id: null,
+						cluster: null,
+						category_type_id: null,
+						category_type_name: null,
+						beneficiary_type_id: null,
+						beneficiary_type_name: null,
+						activity_type_id: null,
+						activity_type_name: null,
+						activity_description_id: null,
+						activity_description_name: null,
+						delivery_type_id: null,
+						delivery_type_name: null,
+						transfer_type_id: 0,
+						transfer_type_value: 0
+					};
+
+					// cleaned non value beneficiary object
+					var inserted_target_benf = {
+						cluster_id: p.cluster_id,
+						cluster: p.cluster,
+						category_type_id: p.category_type_id,
+						category_type_name: p.category_type_name,
+						beneficiary_type_id: p.beneficiary_type_id,
+						beneficiary_type_name: p.beneficiary_type_name,
+						activity_type_id: p.activity_type_id,
+						activity_type_name: p.activity_type_name,
+						activity_description_id: p.activity_description_id,
+						activity_description_name: p.activity_description_name,
+						delivery_type_id: p.delivery_type_id,
+						delivery_type_name: p.delivery_type_name,
+						transfer_type_id: 0,
+						transfer_type_value: 0,
+						default_beneficiary: true,
+					};
+
+					if (p.mpc_delivery_type_id&&p.mpc_delivery_type_name){
+						var add_mpc = {
+							mpc_delivery_type_id: p.mpc_delivery_type_id,
+							mpc_delivery_type_name: p.mpc_delivery_type_id
+						}
+						angular.merge(inserted_target_benf, add_mpc);
+					}
+
+					// construct cleaned beneficiary
+					angular.merge(inserted, inserted_target_benf, sadd);
+
+					target_beneficiaries_array.push(inserted);
+				})
+				// for each location
+				angular.forEach(report.locations, function (l, i) {
+					// if no beneficiaries, add default target beneficiaries
+					if (!l.beneficiaries.length) {
+						var target_beneficiaries_array_copy = angular.copy(target_beneficiaries_array);
+						angular.forEach(target_beneficiaries_array_copy, function (b, i) {
+							l.beneficiaries.push(b)
+						})
+						// check if in report there are beneficiaries, absent but in project defaults
+						// case when user adds in project def, to show in the same month
+						// no functnlty to not show if user deletes in the same month
+						// maybe better to delete it on backend
+						// could be excessive and bug prone
+					} else {
+						// for report location
+						var report_cleaned_beneficiaries_array = [];
+						// comparation lines
+						angular.forEach(l.beneficiaries, function (b, i) {
+
+							var existing_target_benf = {
+								cluster_id: b.cluster_id,
+								cluster: b.cluster,
+								category_type_id: b.category_type_id,
+								category_type_name: b.category_type_name,
+								beneficiary_type_id: b.beneficiary_type_id,
+								beneficiary_type_name: b.beneficiary_type_name,
+								activity_type_id: b.activity_type_id,
+								activity_type_name: b.activity_type_name,
+								activity_description_id: b.activity_description_id,
+								activity_description_name: b.activity_description_name,
+								delivery_type_id: b.delivery_type_id,
+								delivery_type_name: b.delivery_type_name,
+							};
+
+							if (b.mpc_delivery_type_id&&b.mpc_delivery_type_name){
+								var add_mpc = {
+									mpc_delivery_type_id: b.mpc_delivery_type_id,
+									mpc_delivery_type_name: b.mpc_delivery_type_id
+								}
+								angular.merge(existing_target_benf, add_mpc);
+							};
+
+							report_cleaned_beneficiaries_array.push(existing_target_benf);
+						})
+
+						// check each project target beneficiary with reports
+						angular.forEach(project.target_beneficiaries, function (p, i) {
+							var target_benf = {
+								cluster_id: p.cluster_id,
+								cluster: p.cluster,
+								category_type_id: p.category_type_id,
+								category_type_name: p.category_type_name,
+								beneficiary_type_id: p.beneficiary_type_id,
+								beneficiary_type_name: p.beneficiary_type_name,
+								activity_type_id: p.activity_type_id,
+								activity_type_name: p.activity_type_name,
+								activity_description_id: p.activity_description_id,
+								activity_description_name: p.activity_description_name,
+								delivery_type_id: p.delivery_type_id,
+								delivery_type_name: p.delivery_type_name,
+							};
+
+							if (p.mpc_delivery_type_id&&p.mpc_delivery_type_name){
+								var add_mpc = {
+									mpc_delivery_type_id: p.mpc_delivery_type_id,
+									mpc_delivery_type_name: p.mpc_delivery_type_id
+								}
+								angular.merge(target_benf, add_mpc);
+							};
+
+							var sadd = {
+								units: 0,
+								cash_amount: 0,
+								households: 0,
+								sessions: 0,
+								families: 0,
+								boys: 0,
+								girls: 0,
+								men: 0,
+								women: 0,
+								elderly_men: 0,
+								elderly_women: 0
+							};
+
+							var addon = {
+								transfer_type_id: 0,
+								transfer_type_value: 0,
+								default_beneficiary: true,
+							};
+
+							var eq = 0;
+							var flag = true;
+
+							// find if target beneficiary does not exists in report location
+							angular.forEach(report_cleaned_beneficiaries_array, function (rb, i) {
+								if (flag && angular.equals(target_benf, rb))
+								{eq += 1;
+									flag = false;}
+							})
+
+							if (!eq) {
+								var target_benf_copy = angular.copy(target_benf);
+								angular.merge(target_benf_copy, sadd, addon);
+								l.beneficiaries.push(target_benf_copy);
+
+							}
+
+						})
+					}
+				})
+			},
+
+
+
 			// set project details
 			setProjectDetails: function( data ){
 
@@ -74,6 +261,7 @@ angular.module('ngmReportHub')
 				// report
 				$scope.report.definition = data[1].data;
 
+				$scope.report.addDefaultBeneficiaries($scope.report.definition, $scope.report.project);
 				// set report for downloads
 				$scope.report.report = $scope.report.project.organization + '_' + $scope.report.project.cluster + '_' + $scope.report.project.project_title.replace(/\ /g, '_') + '_extracted-' + moment().format( 'YYYY-MM-DDTHHmm' );
 
@@ -130,7 +318,7 @@ angular.module('ngmReportHub')
 							}]
 						}
 					},
-					rows: [{		
+					rows: [{
 						columns: [{
 							styleClass: 's12 m12 l12',
 							widgets: [{
@@ -160,7 +348,7 @@ angular.module('ngmReportHub')
 				// assign to ngm app scope
 				$scope.report.ngm.dashboard.model = $scope.model;
 
-			}			
+			}
 
 		}
 
@@ -171,5 +359,5 @@ angular.module('ngmReportHub')
 			$scope.report.setProjectDetails( results );
 
 		});
-		
+
 	}]);

--- a/app/scripts/modules/cluster/reports/forms/cluster.project.form.report.js
+++ b/app/scripts/modules/cluster/reports/forms/cluster.project.form.report.js
@@ -263,7 +263,8 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
             delivery_type_id: null,
             delivery_type_name: null,
             transfer_type_id: 0,
-            transfer_type_value: 0
+						transfer_type_value: 0,
+						added_beneficiary: true,
           };
 
           // merge
@@ -750,7 +751,9 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
 
         // remove from array if no id
         cancelEdit: function( $parent, $index ) {
-          if ( !$scope.project.report.locations[ $parent ].beneficiaries[ $index ].id ) {
+        	if (!$scope.project.report.locations[$parent].beneficiaries[$index].id &&
+						 (!$scope.project.report.locations[$parent].beneficiaries[$index].default_beneficiary ||
+							 $scope.project.report.locations[$parent].beneficiaries[$index].added_beneficiary)) {
             $scope.project.report.locations[ $parent ].beneficiaries.splice( $index, 1 );
           }
         },
@@ -854,10 +857,11 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
         // remove beneficiary
         removeBeneficiary: function() {
 
-          // b
+          // depending on if has or hasnt id set
           var b = $scope.project.report.locations[ $scope.project.locationIndex ].beneficiaries[ $scope.project.beneficiaryIndex ];
           $scope.project.report.locations[ $scope.project.locationIndex ].beneficiaries.splice( $scope.project.beneficiaryIndex, 1 );
 
+					if (b.id){
           // setReportRequest
           var setBeneficiariesRequest = {
             method: 'POST',
@@ -885,6 +889,9 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
             // update
             Materialize.toast( 'Error!', 6000, 'error' );
           });
+				 } else {
+							$scope.project.save( false, false );
+				 }
         },
 
         // save form on enter


### PR DESCRIPTION
Before first save of monthly report, report will be populated with default target beneficiaries data.
spin off of addBeneficiary funtion

last commit comments functionality for the case when a user adds in project definition target benef after saving of monthly report, and it loops through the monthly report and adds it.

![2018-01-31_23-32-25](https://user-images.githubusercontent.com/29349472/35641897-10310d96-06df-11e8-88bf-6ef87e04ce5c.gif)
