### PR TITLE
feature: admin/5w dash protection cpie activity filter

### DIFF
--- a/app/scripts/modules/cluster/app.js
+++ b/app/scripts/modules/cluster/app.js
@@ -220,74 +220,74 @@ angular
 
 			// DEFAULT
 			.when( '/cluster/admin', {
-				redirectTo: '/cluster/admin/all/all/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/all/all/all/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 
 			// HQ SUPERADMIN BY CLUSTER
 			.when( '/cluster/admin/all/all/agriculture', {
-				redirectTo: '/cluster/admin/all/all/agriculture/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/all/all/all/agriculture/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 			.when( '/cluster/admin/all/all/education', {
-				redirectTo: '/cluster/admin/all/all/education/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/all/all/all/education/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 			.when( '/cluster/admin/all/all/esnfi', {
-				redirectTo: '/cluster/admin/all/all/esnfi/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/all/all/all/esnfi/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 			.when( '/cluster/admin/all/all/fsac', {
-				redirectTo: '/cluster/admin/all/all/fsac/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/all/all/all/fsac/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 			.when( '/cluster/admin/all/all/health', {
-				redirectTo: '/cluster/admin/all/all/health/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/all/all/all/health/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 			.when( '/cluster/admin/all/all/nutrition', {
-				redirectTo: '/cluster/admin/all/all/nutrition/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/all/all/all/nutrition/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 			.when( '/cluster/admin/all/all/cvwg', {
-				redirectTo: '/cluster/admin/all/all/cvwg/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/all/all/all/cvwg/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 			.when( '/cluster/admin/all/all/protection', {
-				redirectTo: '/cluster/admin/all/all/protection/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/all/all/all/protection/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 			.when( '/cluster/admin/all/all/wash', {
-				redirectTo: '/cluster/admin/all/all/wash/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/all/all/all/wash/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 			
 			// AFRO
 			.when( '/cluster/admin/afro', {
-				redirectTo: '/cluster/admin/afro/all/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/afro/all/all/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 			.when( '/cluster/admin/afro/cd', {
-				redirectTo: '/cluster/admin/afro/cd/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/afro/cd/all/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 			.when( '/cluster/admin/afro/et', {
-				redirectTo: '/cluster/admin/afro/et/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/afro/et/all/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 			.when( '/cluster/admin/afro/ng', {
-				redirectTo: '/cluster/admin/afro/ng/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/afro/ng/all/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 			.when( '/cluster/admin/afro/ss', {
-				redirectTo: '/cluster/admin/afro/ss/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/afro/ss/all/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 
 			// EMRO
 			.when( '/cluster/admin/emro', {
-				redirectTo: '/cluster/admin/emro/all/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/emro/all/all/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 			.when( '/cluster/admin/emro/af', {
-				redirectTo: '/cluster/admin/emro/af/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/emro/af/all/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 			.when( '/cluster/admin/emro/so', {
-				redirectTo: '/cluster/admin/emro/so/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/emro/so/all/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 			.when( '/cluster/admin/emro/sy', {
-				redirectTo: '/cluster/admin/emro/sy/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/emro/sy/all/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 			.when( '/cluster/admin/emro/ur', {
-				redirectTo: '/cluster/admin/emro/ur/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
+				redirectTo: '/cluster/admin/emro/ur/all/all/all/activity/' + moment.utc().startOf( 'M' ).format( 'YYYY-MM-DD' ) + '/' + moment().endOf( 'M' ).format('YYYY-MM-DD')
 			})
 
 			// ADMIN
-			.when( '/cluster/admin/:adminRpcode/:admin0pcode/:cluster_id/:organization_tag/:report_type/:start/:end', {
+			.when( '/cluster/admin/:adminRpcode/:admin0pcode/:cluster_id/:activity_type_id/:organization_tag/:report_type/:start/:end', {
 				templateUrl: '/views/app/dashboard.html',
 				controller: 'DashboardClusterAdminCtrl',
 				resolve: {
@@ -322,7 +322,7 @@ angular
 						var adminRpcode =ngmUser.get() && ngmUser.get().adminRpcode ? ngmUser.get().adminRpcode.toLowerCase() : 'hq';
 						var admin0pcode =ngmUser.get() && ngmUser.get().admin0pcode ? ngmUser.get().admin0pcode.toLowerCase() : 'all'; 
 						var cluster_id = ngmUser.get() && ngmUser.get().cluster_id ? ngmUser.get().cluster_id : 'all';
-						var url = '/cluster/5w/' + adminRpcode + '/' + admin0pcode + '/all/all/' + cluster_id + '/all/all/2018-01-01/' + moment().format('YYYY-MM-DD');
+						var url = '/cluster/5w/' + adminRpcode + '/' + admin0pcode + '/all/all/' + cluster_id + '/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD');
 						$location.path( url );
 					}]
 				},
@@ -333,7 +333,7 @@ angular
 						var adminRpcode =ngmUser.get() && ngmUser.get().adminRpcode ? ngmUser.get().adminRpcode.toLowerCase() : 'hq';
 						var admin0pcode =ngmUser.get() && ngmUser.get().admin0pcode ? ngmUser.get().admin0pcode.toLowerCase() : 'all'; 
 						var cluster_id = ngmUser.get() && ngmUser.get().cluster_id ? ngmUser.get().cluster_id : 'all';
-						var url = '/cluster/5w/' + adminRpcode + '/' + admin0pcode + '/all/all/' + cluster_id + '/all/all/2018-01-01/' + moment().format('YYYY-MM-DD');
+						var url = '/cluster/5w/' + adminRpcode + '/' + admin0pcode + '/all/all/' + cluster_id + '/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD');
 						$location.path( url );
 					}]
 				},
@@ -350,43 +350,43 @@ angular
 
 			// cluster dashboard HQ
 			.when( '/cluster/5w/hq/all', {
-				redirectTo: '/cluster/5w/hq/all/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
+				redirectTo: '/cluster/5w/hq/all/all/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
 			})
 			// cluster dashboard AFRO
 			.when( '/cluster/5w/afro/all', {
-				redirectTo: '/cluster/5w/afro/all/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
+				redirectTo: '/cluster/5w/afro/all/all/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
 			})
 			.when( '/cluster/5w/afro/cd', {
-				redirectTo: '/cluster/5w/afro/cd/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
+				redirectTo: '/cluster/5w/afro/cd/all/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
 			})
 			.when( '/cluster/5w/afro/et', {
-				redirectTo: '/cluster/5w/afro/et/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
+				redirectTo: '/cluster/5w/afro/et/all/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
 			})
 			.when( '/cluster/5w/afro/ng', {
-				redirectTo: '/cluster/5w/afro/ng/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
+				redirectTo: '/cluster/5w/afro/ng/all/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
 			})
 			.when( '/cluster/5w/afro/ss', {
-				redirectTo: '/cluster/5w/afro/ss/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
+				redirectTo: '/cluster/5w/afro/ss/all/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
 			})
 			// cluster dashboard EMRO
 			.when( '/cluster/5w/emro/all', {
-				redirectTo: '/cluster/5w/emro/all/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
+				redirectTo: '/cluster/5w/emro/all/all/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
 			})
 			.when( '/cluster/5w/emro/af', {
-				redirectTo: '/cluster/5w/emro/af/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
+				redirectTo: '/cluster/5w/emro/af/all/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
 			})
 			.when( '/cluster/5w/emro/so', {
-				redirectTo: '/cluster/5w/emro/so/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
+				redirectTo: '/cluster/5w/emro/so/all/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
 			})
 			.when( '/cluster/5w/emro/sy', {
-				redirectTo: '/cluster/5w/emro/sy/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
+				redirectTo: '/cluster/5w/emro/sy/all/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
 			})
 			.when( '/cluster/5w/emro/ur', {
-				redirectTo: '/cluster/5w/emro/ur/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
+				redirectTo: '/cluster/5w/emro/ur/all/all/all/all/all/all/2018-01-01/' + moment().format('YYYY-MM-DD')
 			})
 
 			// health dashboard
-			.when( '/cluster/5w/:adminRpcode/:admin0pcode/:admin1pcode/:admin2pcode/:cluster_id/:organization_tag/:beneficiaries/:start/:end', {
+			.when( '/cluster/5w/:adminRpcode/:admin0pcode/:admin1pcode/:admin2pcode/:cluster_id/:activity_type_id/:organization_tag/:beneficiaries/:start/:end', {
 				templateUrl: '/views/app/dashboard.html',
 				controller: 'DashboardClusterCtrl',
 				resolve: {

--- a/app/scripts/modules/cluster/dashboards/dashboard.admin.js
+++ b/app/scripts/modules/cluster/dashboards/dashboard.admin.js
@@ -140,13 +140,14 @@ angular.module('ngmReportHub')
 				},
 
 				// admin
-				getPath: function( cluster_id, report_type, organization_tag ){
+				getPath: function( cluster_id, activity_type_id, report_type, organization_tag ){
 
 					var path = '/cluster/admin/' + $scope.dashboard.adminRpcode.toLowerCase() +
 												 '/' + $scope.dashboard.admin0pcode.toLowerCase() +
 												 '/' + cluster_id +
+												 '/' + activity_type_id +
 												 '/' + organization_tag +
-												 '/' + report_type +
+												 '/' + report_type +												 
 												 '/' + $scope.dashboard.startDate +
 												 '/' + $scope.dashboard.endDate;
 
@@ -157,7 +158,7 @@ angular.module('ngmReportHub')
 				setUrl: function(){
 
 					// if ADMIN
-					var path = $scope.dashboard.getPath( $scope.dashboard.cluster_id, $scope.dashboard.report_type, $scope.dashboard.organization_tag );
+					var path = $scope.dashboard.getPath( $scope.dashboard.cluster_id, $scope.dashboard.activity_type_id, $scope.dashboard.report_type, $scope.dashboard.organization_tag );
 
 					// if current location is not equal to path
 					if ( path !== $location.$$path ) {
@@ -178,6 +179,7 @@ angular.module('ngmReportHub')
 						adminRpcode: $scope.dashboard.adminRpcode,
 						admin0pcode: $scope.dashboard.admin0pcode,
 						report_type: $scope.dashboard.report_type,
+						activity_type_id: $scope.dashboard.activity_type_id,
 						start_date: $scope.dashboard.startDateReport,
 						end_date: $scope.dashboard.endDateReport
 					}
@@ -197,6 +199,7 @@ angular.module('ngmReportHub')
 							admin1pcode: 'all',
 							admin2pcode: 'all',
 							cluster_id: $scope.dashboard.cluster_id,
+							activity_type_id: $scope.dashboard.activity_type_id,
 							organization_tag: $scope.dashboard.organization_tag,
 							beneficiaries: ['all'],
 							start_date: $scope.dashboard.startDateReport,
@@ -291,7 +294,7 @@ angular.module('ngmReportHub')
 						angular.forEach( $scope.dashboard.lists.clusters, function(d,i){
 
 							// admin URL
-							var path = $scope.dashboard.getPath( d.cluster_id, $scope.dashboard.report_type, $scope.dashboard.organization_tag );
+							var path = $scope.dashboard.getPath( d.cluster_id, 'all', $scope.dashboard.report_type, $scope.dashboard.organization_tag );
 
 							// menu rows
 							clusterRows.push({
@@ -317,6 +320,7 @@ angular.module('ngmReportHub')
 
 					// reports
 					$scope.dashboard.setReportMenu();
+					$scope.dashboard.setActivityMenu();
 
 					// not user
 					if( role !== 'user' ){
@@ -338,7 +342,7 @@ angular.module('ngmReportHub')
 							organizations.forEach(function( d, i ){
 
 								// admin URL
-								var path = $scope.dashboard.getPath( $scope.dashboard.cluster_id, $scope.dashboard.report_type, d.organization_tag );
+								var path = $scope.dashboard.getPath( $scope.dashboard.cluster_id, $scope.dashboard.activity_type_id, $scope.dashboard.report_type, d.organization_tag );
 
 								// menu rows
 								orgRows.push({
@@ -407,6 +411,12 @@ angular.module('ngmReportHub')
 					if ( $scope.dashboard.cluster_id !== 'all' ) {
 						$scope.dashboard.title += ' | ' + $scope.dashboard.cluster.cluster;
 					}
+
+					// activity
+					if ( $scope.dashboard.activity_type_id !== 'all' ) {
+						$scope.dashboard.title += ' | ' + $scope.dashboard.activity_type_id.toUpperCase();
+					}
+
 					// org
 					if ( $scope.dashboard.organization_tag !== 'all' ) {
 						var org = $scope.dashboard.organization ? ' | ' + $scope.dashboard.organization : '';
@@ -444,6 +454,12 @@ angular.module('ngmReportHub')
 					}	else {
 						$scope.dashboard.subtitle += ', '+ $scope.dashboard.cluster.cluster.toUpperCase() + ' cluster';
 					}
+
+					// activity
+					if ( $scope.dashboard.activity_type_id !== 'all' ) {
+						$scope.dashboard.subtitle += ', ' + $scope.dashboard.activity_type_id.toUpperCase();
+					}
+
 					// org
 					if ( $scope.dashboard.organization_tag === 'all' ) {
 						$scope.dashboard.subtitle += ', ALL organizations';
@@ -481,18 +497,44 @@ angular.module('ngmReportHub')
 							'param': 'report_type',
 							'active': 'activity',
 							'class': 'grey-text text-darken-2 waves-effect waves-teal waves-teal-lighten-4',
-							'href': '/desk/#' + $scope.dashboard.getPath( $scope.dashboard.cluster_id, 'activity', $scope.dashboard.organization_tag )
+							'href': '/desk/#' + $scope.dashboard.getPath( $scope.dashboard.cluster_id, $scope.dashboard.activity_type_id, 'activity', $scope.dashboard.organization_tag )
 						},{
 							'title': 'STOCK',
 							'param': 'report_type',
 							'active': 'stock',
 							'class': 'grey-text text-darken-2 waves-effect waves-teal waves-teal-lighten-4',
-							'href': '/desk/#' + $scope.dashboard.getPath( $scope.dashboard.cluster_id, 'stock', $scope.dashboard.organization_tag )
+							'href': '/desk/#' + $scope.dashboard.getPath( $scope.dashboard.cluster_id, $scope.dashboard.activity_type_id, 'stock', $scope.dashboard.organization_tag )
 						}]
 					});
 
 				},
 
+				setActivityMenu: function(){
+					// menu
+					if ($scope.dashboard.report_type === 'activity' && $scope.dashboard.cluster_id === 'protection' ) {
+					
+						$scope.model.menu.push({
+							'search': false,
+							'id': 'search-cluster-activity',
+							'icon': 'autorenew',
+							'title': 'Activity',
+							'class': 'teal lighten-1 white-text',
+							'rows': [{
+								'title': 'ALL',
+								'param': 'activity_type_id',
+								'active': 'all',
+								'class': 'grey-text text-darken-2 waves-effect waves-teal waves-teal-lighten-4',
+								'href': '/desk/#' + $scope.dashboard.getPath( $scope.dashboard.cluster_id, 'all', 'activity', $scope.dashboard.organization_tag )
+							},{
+								'title': 'CPiE',
+								'param': 'activity_type_id',
+								'active': 'cpie',
+								'class': 'grey-text text-darken-2 waves-effect waves-teal waves-teal-lighten-4',
+								'href': '/desk/#' + $scope.dashboard.getPath( $scope.dashboard.cluster_id, 'cpie', 'activity', $scope.dashboard.organization_tag )
+							}]
+						});
+					}
+				},
 				// set dashboard
 				setDashboard: function(){
 
@@ -502,6 +544,7 @@ angular.module('ngmReportHub')
 					$scope.dashboard.cluster_id = $route.current.params.cluster_id;
 					$scope.dashboard.organization_tag = $route.current.params.organization_tag;
 					$scope.dashboard.report_type = $route.current.params.report_type;
+					$scope.dashboard.activity_type_id = $route.current.params.activity_type_id;
 					// report name
 					$scope.dashboard.report_file_name += moment().format( 'YYYY-MM-DDTHHmm' );
 
@@ -534,6 +577,14 @@ angular.module('ngmReportHub')
 
 					if ($route.current.params.organization_tag!=='all'){
 						$scope.dashboard.cluster_id_filename = $route.current.params.organization_tag + '_' + $scope.dashboard.cluster_id_filename;
+					}
+
+					if ($route.current.params.activity_type_id!=='all'){
+						$scope.dashboard.activity_filename = $route.current.params.activity_type_id + '_';
+					}
+
+					if ($route.current.params.activity_type_id==='all'){
+						$scope.dashboard.activity_filename = '';
 					}
 
 					// model
@@ -569,7 +620,7 @@ angular.module('ngmReportHub')
 											// set new date
 											$scope.dashboard.startDate = date;
 											// URL
-											var path = $scope.dashboard.getPath( $route.current.params.cluster_id, $route.current.params.report_type, $route.current.params.organization_tag );
+											var path = $scope.dashboard.getPath( $route.current.params.cluster_id, $scope.dashboard.activity_type_id, $route.current.params.report_type, $route.current.params.organization_tag );
 											// update new date
 											$location.path( path );
 
@@ -588,7 +639,7 @@ angular.module('ngmReportHub')
 											// set new date
 											$scope.dashboard.endDate = date;
 											// URL
-											var path = $scope.dashboard.getPath( $route.current.params.cluster_id, $route.current.params.report_type, $route.current.params.organization_tag );
+											var path = $scope.dashboard.getPath( $route.current.params.cluster_id, $scope.dashboard.activity_type_id, $route.current.params.report_type, $route.current.params.organization_tag );
 											// update new date
 											$location.path( path );
 										}
@@ -660,7 +711,7 @@ angular.module('ngmReportHub')
 									color: 'blue lighten-2',
 									icon: 'group',
 									hover: 'Download Beneficiary Data as CSV',
-									request: $scope.dashboard.getCsvRequest( { csv: true, indicator: 'beneficiaries', report: $scope.dashboard.cluster_id_filename + '_beneficiary_data-extracted-from-' + $scope.dashboard.startDate + '-to-' + $scope.dashboard.endDate + '-extracted-' + moment().format( 'YYYY-MM-DDTHHmm' ) } ),
+									request: $scope.dashboard.getCsvRequest( { csv: true, indicator: 'beneficiaries', report: $scope.dashboard.activity_filename + $scope.dashboard.cluster_id_filename + '_beneficiary_data-extracted-from-' + $scope.dashboard.startDate + '-to-' + $scope.dashboard.endDate + '-extracted-' + moment().format( 'YYYY-MM-DDTHHmm' ) } ),
 									metrics: $scope.dashboard.getMetrics( 'beneficiary_data', 'csv' )
 								},{
 									type: 'csv',

--- a/app/scripts/modules/cluster/dashboards/dashboard.cluster.js
+++ b/app/scripts/modules/cluster/dashboards/dashboard.cluster.js
@@ -100,7 +100,7 @@ angular.module('ngmReportHub')
 				}],
 
 				// admin
-				getPath: function( cluster_id, organization_tag, admin1pcode, admin2pcode ){
+				getPath: function( cluster_id, activity_type_id, organization_tag, admin1pcode, admin2pcode ){
 
 					if ( cluster_id !== 'rnr_chapter' ) {
 						var path = '/cluster/5w/' + $scope.dashboard.adminRpcode +
@@ -108,6 +108,7 @@ angular.module('ngmReportHub')
 																	'/' + admin1pcode +
 																	'/' + admin2pcode +
 																	'/' + cluster_id +
+																	'/' + activity_type_id +
 																	'/' + organization_tag +
 																	'/' + $scope.dashboard.beneficiaries.join('+') +
 																	'/' + $scope.dashboard.startDate +
@@ -118,8 +119,9 @@ angular.module('ngmReportHub')
 																	'/' + admin1pcode +
 																	'/' + admin2pcode +
 																	'/' + cluster_id +
+																	'/' + activity_type_id +
 																	'/' + organization_tag +
-																	'/returnee_undocumented+returnee_documented+refugee_pakistani' +
+																	'/returnee_undocumented+returnee_documented+refugee_pakistani' +																	
 																	'/' + $scope.dashboard.startDate +
 																	'/' + $scope.dashboard.endDate;
 					}
@@ -131,7 +133,7 @@ angular.module('ngmReportHub')
 				setUrl: function(){
 
 					// get url
-					var path = $scope.dashboard.getPath( $scope.dashboard.cluster_id, $scope.dashboard.organization_tag, $scope.dashboard.admin1pcode, $scope.dashboard.admin2pcode );
+					var path = $scope.dashboard.getPath( $scope.dashboard.cluster_id, $scope.dashboard.activity_type_id, $scope.dashboard.organization_tag, $scope.dashboard.admin1pcode, $scope.dashboard.admin2pcode );
 
 					// if current location is not equal to path
 					if ( path !== $location.$$path ) {
@@ -151,6 +153,7 @@ angular.module('ngmReportHub')
 							admin1pcode: $scope.dashboard.admin1pcode,
 							admin2pcode: $scope.dashboard.admin2pcode,
 							cluster_id: $scope.dashboard.cluster_id,
+							activity_type_id: $scope.dashboard.activity_type_id,
 							organization_tag: $scope.dashboard.organization_tag,
 							beneficiaries: $scope.dashboard.beneficiaries,
 							start_date: $scope.dashboard.startDate,
@@ -276,7 +279,7 @@ angular.module('ngmReportHub')
 						// clusters
 						$scope.dashboard.lists.clusters.unshift({ cluster_id: 'all', cluster: 'ALL' });
 						angular.forEach( $scope.dashboard.lists.clusters, function(d,i){
-							var path = $scope.dashboard.getPath( d.cluster_id, $scope.dashboard.organization_tag, $scope.dashboard.admin1pcode, $scope.dashboard.admin2pcode );
+							var path = $scope.dashboard.getPath( d.cluster_id, 'all', $scope.dashboard.organization_tag, $scope.dashboard.admin1pcode, $scope.dashboard.admin2pcode );
 							clusterRows.push({
 								'title': d.cluster,
 								'param': 'cluster_id',
@@ -296,10 +299,35 @@ angular.module('ngmReportHub')
 							'rows': clusterRows
 						});
 
+						// activity menu 
+						if ( $scope.dashboard.cluster_id === 'protection' ) {
+						
+							$scope.model.menu.push({
+								'search': false,
+								'id': 'search-cluster-activity',
+								'icon': 'assignment_turned_in',
+								'title': 'Activity',
+								'class': 'teal lighten-1 white-text',
+								'rows': [{
+									'title': 'ALL',
+									'param': 'activity_type_id',
+									'active': 'all',
+									'class': 'grey-text text-darken-2 waves-effect waves-teal waves-teal-lighten-4',
+									'href': '/desk/#' + $scope.dashboard.getPath( $scope.dashboard.cluster_id, 'all', $scope.dashboard.organization_tag, $scope.dashboard.admin1pcode, $scope.dashboard.admin2pcode )
+								},{
+									'title': 'CPiE',
+									'param': 'activity_type_id',
+									'active': 'cpie',
+									'class': 'grey-text text-darken-2 waves-effect waves-teal waves-teal-lighten-4',
+									'href': '/desk/#' + $scope.dashboard.getPath( $scope.dashboard.cluster_id, 'cpie', $scope.dashboard.organization_tag, $scope.dashboard.admin1pcode, $scope.dashboard.admin2pcode )
+								}]
+							});
+						}
+
 						// organizations
 						organizations.forEach(function( d, i ){
 							if ( d ) {
-								var path = $scope.dashboard.getPath( $scope.dashboard.cluster_id, d.organization_tag, $scope.dashboard.admin1pcode, $scope.dashboard.admin2pcode );
+								var path = $scope.dashboard.getPath( $scope.dashboard.cluster_id, $scope.dashboard.activity_type_id, d.organization_tag, $scope.dashboard.admin1pcode, $scope.dashboard.admin2pcode );
 								orgRows.push({
 									'title': d.organization,
 									'param': 'organization_tag',
@@ -334,9 +362,9 @@ angular.module('ngmReportHub')
 								admin1name: 'ALL',
 							});
 							angular.forEach( admin1List, function(d,i){
-								var path = $scope.dashboard.getPath( $scope.dashboard.cluster_id, $scope.dashboard.organization_tag, d.admin1pcode, 'all' );
+								var path = $scope.dashboard.getPath( $scope.dashboard.cluster_id, $scope.dashboard.activity_type_id, $scope.dashboard.organization_tag, d.admin1pcode, 'all' );
 								provinceRows.push({
-									'title': d.admin1name,
+									'title': d.inactive ? d.admin1name + ' (Old)' : d.admin1name,
 									'param': 'admin1pcode',
 									'active': d.admin1pcode,
 									'class': 'grey-text text-darken-2 waves-effect waves-teal waves-teal-lighten-4',
@@ -366,7 +394,7 @@ angular.module('ngmReportHub')
 								admin2name: 'ALL',
 							});
 							angular.forEach( admin2List, function(d,i){
-								var path = $scope.dashboard.getPath( $scope.dashboard.cluster_id, $scope.dashboard.organization_tag, $scope.dashboard.admin1pcode, d.admin2pcode );
+								var path = $scope.dashboard.getPath( $scope.dashboard.cluster_id, $scope.dashboard.activity_type_id, $scope.dashboard.organization_tag, $scope.dashboard.admin1pcode, d.admin2pcode );
 								districtRows.push({
 									'title': d.admin2name,
 									'param': 'admin2pcode',
@@ -431,6 +459,10 @@ angular.module('ngmReportHub')
 					if ( $scope.dashboard.cluster_id !== 'all' ) {
 						$scope.dashboard.title += ' | ' + $scope.dashboard.cluster.cluster.toUpperCase();
 					}
+					// activity
+					if ( $scope.dashboard.activity_type_id !== 'all' ) {
+						$scope.dashboard.title += ' | ' + $scope.dashboard.activity_type_id.toUpperCase();
+					}
 					// org
 					if ( $scope.dashboard.organization_tag !== 'all' ) {
 						var org = $scope.dashboard.organization ? ' | ' + $scope.dashboard.organization : '';
@@ -468,6 +500,10 @@ angular.module('ngmReportHub')
 					}	else {
 						$scope.dashboard.subtitle += ', ' + $scope.dashboard.cluster.cluster.toUpperCase() + ' cluster';
 					}
+					// activity
+					if ( $scope.dashboard.activity_type_id !== 'all' ) {
+						$scope.dashboard.subtitle += ', ' + $scope.dashboard.activity_type_id.toUpperCase();
+					}
 					// org
 					if ( $scope.dashboard.organization_tag === 'all' ) {
 						$scope.dashboard.subtitle += ', ALL organizations';
@@ -502,6 +538,7 @@ angular.module('ngmReportHub')
 					$scope.dashboard.cluster_id = $route.current.params.cluster_id;
 					$scope.dashboard.organization_tag = $route.current.params.organization_tag;
 					$scope.dashboard.beneficiaries = $route.current.params.beneficiaries.split('+');
+					$scope.dashboard.activity_type_id = $route.current.params.activity_type_id;
 
 					// ADMIN
 					if ( $scope.dashboard.user.roles && $scope.dashboard.user.roles.indexOf( 'SUPERADMIN' ) === -1 ) {
@@ -528,6 +565,14 @@ angular.module('ngmReportHub')
 					// filename cluster needs to be mpc for cvwg
 					// TODO refactor/update cvwg
 					$scope.dashboard.cluster_id_filename = $scope.dashboard.cluster_id !== 'cvwg' ? $scope.dashboard.cluster_id : 'mpc'
+
+					if ($route.current.params.activity_type_id!=='all'){
+						$scope.dashboard.activity_filename = $route.current.params.activity_type_id + '_';
+					}
+
+					if ($route.current.params.activity_type_id==='all'){
+						$scope.dashboard.activity_filename = '';
+					}
 
 					// model
 					$scope.model = {
@@ -561,7 +606,7 @@ angular.module('ngmReportHub')
 										if ( date !== $scope.dashboard.startDate ) {
 											// set new date
 											$scope.dashboard.startDate = date;
-											var path = $scope.dashboard.getPath( $scope.dashboard.cluster_id, $scope.dashboard.organization_tag, $scope.dashboard.admin1pcode, $scope.dashboard.admin2pcode );
+											var path = $scope.dashboard.getPath( $scope.dashboard.cluster_id, $scope.dashboard.activity_type_id, $scope.dashboard.organization_tag, $scope.dashboard.admin1pcode, $scope.dashboard.admin2pcode );
 											$location.path( path );
 										}
 									}
@@ -577,7 +622,7 @@ angular.module('ngmReportHub')
 										if ( date !== $scope.dashboard.endDate ) {
 											// set new date
 											$scope.dashboard.endDate = date;
-											var path = $scope.dashboard.getPath( $scope.dashboard.cluster_id, $scope.dashboard.organization_tag, $scope.dashboard.admin1pcode, $scope.dashboard.admin2pcode );
+											var path = $scope.dashboard.getPath( $scope.dashboard.cluster_id, $scope.dashboard.activity_type_id, $scope.dashboard.organization_tag, $scope.dashboard.admin1pcode, $scope.dashboard.admin2pcode );
 											$location.path( path );
 										}
 									}
@@ -638,7 +683,7 @@ angular.module('ngmReportHub')
 									color: 'blue lighten-2',
 									icon: 'group',
 									hover: 'Download Beneficiary Data as CSV',
-									request: $scope.dashboard.getRequest( { csv: true, indicator: 'beneficiaries', report: $scope.dashboard.cluster_id_filename + '_beneficiary_data-extracted-from-' + $scope.dashboard.startDate + '-to-' + $scope.dashboard.endDate + '-extracted-' + moment().format( 'YYYY-MM-DDTHHmm' ) } ),
+									request: $scope.dashboard.getRequest( { csv: true, indicator: 'beneficiaries', report: $scope.dashboard.activity_filename + $scope.dashboard.cluster_id_filename + '_beneficiary_data-extracted-from-' + $scope.dashboard.startDate + '-to-' + $scope.dashboard.endDate + '-extracted-' + moment().format( 'YYYY-MM-DDTHHmm' ) } ),
 									metrics: $scope.dashboard.getMetrics( 'beneficiary_data', 'csv' )
 								},{
 									type: 'csv',


### PR DESCRIPTION
Adding _Activity_ filter for Protection CPiE subcluster

![activity_filter](https://user-images.githubusercontent.com/29349472/41973716-0c449742-7a2b-11e8-87f7-9d79756db68b.png) ![cpie_filter](https://user-images.githubusercontent.com/29349472/41973834-693fc00c-7a2b-11e8-83fc-d3d6fa29842d.png)

So far in menu activity filter values are defined on frontend, contains only CPiE. Option only for Protection.
url update: +activity_type_id, values: 'all', 'cpie'
Admin: /cluster/admin/:adminRpcode/:admin0pcode/:cluster_id/:activity_type_id/:organization_tag/:report_type/:start/:end
5w: /cluster/5w/:adminRpcode/:admin0pcode/:admin1pcode/:admin2pcode/:cluster_id/:activity_type_id/:organization_tag/:beneficiaries/:start/:end