### PR TITLE
feat(lists): filter country clusters object

### DIFF
--- a/app/scripts/app/controllers/admin/controller.authentication.js
+++ b/app/scripts/app/controllers/admin/controller.authentication.js
@@ -115,10 +115,10 @@ angular.module('ngm.widget.form.authentication', ['ngm.provider'])
           'wash': { cluster: 'WASH' },
           'undaf':{ cluster: 'UNDAF'}
 				},
-				clusters: ngmClusterLists.getClusters('all'),
+				clusters: ngmClusterLists.getClusters('all').filter(cluster=>cluster.registration!==false),
 				clusterByCountry: function() {					
 					country = $scope.panel.user.admin0pcode? $scope.panel.user.admin0pcode:'all';
-					$scope.panel.clusters = ngmClusterLists.getClusters(country);
+					$scope.panel.clusters = ngmClusterLists.getClusters(country).filter(cluster=>cluster.registration!==false);
 				},
         //cluster:clus,
 

--- a/app/scripts/modules/cluster/dashboards/dashboard.admin.js
+++ b/app/scripts/modules/cluster/dashboards/dashboard.admin.js
@@ -119,7 +119,7 @@ angular.module('ngmReportHub')
 
 				// lists
 				lists: {
-					clusters: ngmClusterLists.getClusters( $route.current.params.admin0pcode ),
+					clusters: ngmClusterLists.getClusters( $route.current.params.admin0pcode ).filter(cluster=>cluster.filter!==false),
 				},
 
 				// filtered data

--- a/app/scripts/modules/cluster/dashboards/dashboard.cluster.js
+++ b/app/scripts/modules/cluster/dashboards/dashboard.cluster.js
@@ -59,7 +59,7 @@ angular.module('ngmReportHub')
 
 				// lists
 				lists: {
-					clusters: ngmClusterLists.getClusters( $route.current.params.admin0pcode ),
+					clusters: ngmClusterLists.getClusters( $route.current.params.admin0pcode ).filter(cluster=>cluster.filter!==false),
 					admin1: localStorage.getObject( 'lists' ) ? localStorage.getObject( 'lists' ).admin1List : [],
 					admin2: localStorage.getObject( 'lists' ) ? localStorage.getObject( 'lists' ).admin2List : [],
 					admin3: localStorage.getObject( 'lists' ) ? localStorage.getObject( 'lists' ).admin3List : []

--- a/app/scripts/modules/cluster/reports/forms/cluster.organization.form.stock.js
+++ b/app/scripts/modules/cluster/reports/forms/cluster.organization.form.stock.js
@@ -60,7 +60,7 @@ angular.module( 'ngm.widget.organization.stock', [ 'ngm.provider' ])
 
         // lists
         lists: {
-          clusters: ngmClusterLists.getClusters( config.organization.admin0pcode ),
+          clusters: ngmClusterLists.getClusters( config.organization.admin0pcode ).filter(cluster=>cluster.filter!==false),
           units: ngmClusterLists.getUnits( config.organization.admin0pcode ),
           stocks: localStorage.getObject( 'lists' ).stockItemsList,
           stock_status:[{

--- a/app/scripts/modules/cluster/reports/services/ngmClusterLists.js
+++ b/app/scripts/modules/cluster/reports/services/ngmClusterLists.js
@@ -40,7 +40,7 @@ angular.module( 'ngmReportHub' )
           mpc_purpose: ngmClusterLists.getMpcPurpose(),
           mpc_mechanism_type: ngmClusterLists.getMpcMechanismTypes(),
           transfers: ngmClusterLists.getTransfers( transfers ),
-          clusters: ngmClusterLists.getClusters( project.admin0pcode ),
+          clusters: ngmClusterLists.getClusters( project.admin0pcode ).filter(cluster=>cluster.project!==false),
           activity_types: ngmClusterLists.getActivities( project, true, 'activity_type_id' ),
           activity_descriptions: ngmClusterLists.getActivities( project, true, 'activity_description_id' ),
           activity_details: ngmClusterLists.getActivities( project, true, 'activity_detail_id' ),
@@ -417,7 +417,7 @@ angular.module( 'ngmReportHub' )
           },{
             cluster_id: 'albergue',
             cluster: 'Alberue'
-          },,{
+          },{
             cluster_id:'san',
             cluster: 'Seguridad Alimentaria y Nutrición (SAN)'
           },
@@ -442,7 +442,8 @@ angular.module( 'ngmReportHub' )
 
           clusters = [{
             cluster_id: 'acbar',
-            cluster: 'ACBAR'
+            cluster: 'ACBAR',
+            registration: false
           },{
             cluster_id: 'agriculture',
             cluster: 'Agriculture'
@@ -480,7 +481,9 @@ angular.module( 'ngmReportHub' )
         }else if ( admin0pcode.toLowerCase() === 'af' ) {
           clusters = [{
             cluster_id: 'acbar',
-            cluster: 'ACBAR'
+            cluster: 'ACBAR',
+            registration: false,
+            project: false
           },{
             cluster_id: 'eiewg',
             cluster: 'EiEWG'
@@ -504,7 +507,10 @@ angular.module( 'ngmReportHub' )
             cluster: 'Protection'
           },{
             cluster_id: 'rnr_chapter',
-            cluster: 'R&R Chapter'
+            cluster: 'R&R Chapter',
+            registration: false,
+            filter: false,
+            project: false
           },{
             cluster_id: 'wash',
             cluster: 'WASH'


### PR DESCRIPTION
as pull request get clusters from getClusters:
getClusters clusters could contain cluster that not open for registration but on cluster object, as a simple solution set additional property like registration: false and filter on getClusters
otherwise, if clusters should be consistent for registration, dashboard filters, project, stocks just to clean up clusters, in case of AF removing ACBAR, RnR chapter