### PR TITLE
feat(lists): use of ngmLists service vs localStorage

### DIFF
--- a/app/scripts/app/app.js
+++ b/app/scripts/app/app.js
@@ -530,4 +530,29 @@ angular
 			}, 1000 );
     });
 
-	}]);
+	}])
+	// service to store lists
+	.factory('ngmLists', function () {
+
+		// storage object
+		obj = {};
+
+		// on instantiation get values from local storage
+		if (localStorage.length) {
+			Object.keys(localStorage).forEach(function (key) {
+				obj[key] = localStorage.getObject(key)
+			});
+		}
+
+		return {
+			setObject: function (key, value) {
+				obj[key] = value;
+			},
+			getObject: function (key) {
+				return obj[key];
+			},
+			removeItem: function (key) {
+				obj[key] = undefined;
+			},
+		}
+	});

--- a/app/scripts/app/controllers/admin/controller.authentication.js
+++ b/app/scripts/app/controllers/admin/controller.authentication.js
@@ -27,9 +27,10 @@ angular.module('ngm.widget.form.authentication', ['ngm.provider'])
     'ngmUser',
     'ngmData',
 		'ngmClusterLists',
+    'ngmLists',
     'config',
     '$translate',
-		function ($scope, $http, $location, $timeout, $filter, $q, ngmAuth, ngmUser, ngmData, ngmClusterLists, config,$translate){
+		function ($scope, $http, $location, $timeout, $filter, $q, ngmAuth, ngmUser, ngmData, ngmClusterLists, ngmLists, config,$translate){
        
 
       // if($location.$$host === "192.168.33.16" || $location.$$host === "35.229.43.63" || $location.$$host === "192.168.33.16" ){
@@ -89,7 +90,7 @@ angular.module('ngm.widget.form.authentication', ['ngm.provider'])
         ],
 
         // duty stations
-        dutyStations: localStorage.getObject( 'dutyStations'),
+        dutyStations: ngmLists.getObject( 'dutyStations'),
 
         // cluster
         cluster: {
@@ -554,6 +555,7 @@ angular.module('ngm.widget.form.authentication', ['ngm.provider'])
         // send request
         $q.all([ $http( getDutyStations ) ] ).then( function( results ){
           localStorage.setObject( 'dutyStations', results[0].data );
+          ngmLists.setObject( 'dutyStations', results[0].data );
           $scope.panel.dutyStations = results[0].data;
         });
 
@@ -585,6 +587,7 @@ angular.module('ngm.widget.form.authentication', ['ngm.provider'])
         // set
         $http.get( ngmAuth.LOCATION + '/api/list/organizations' ).then(function( organizations ){
           localStorage.setObject( 'organizations', organizations.data );
+          ngmLists.setObject( 'organizations', organizations.data );
           $scope.panel.organizations = organizations.data;
 
           

--- a/app/scripts/app/services/ngmAuthentication.js
+++ b/app/scripts/app/services/ngmAuthentication.js
@@ -11,13 +11,13 @@
  *
  */
 angular.module('ngmReportHub')
-	.factory( 'ngmUser', [ '$injector', function( $injector ) {	
+	.factory( 'ngmUser', [ '$injector', 'ngmLists', function( $injector, ngmLists ) {	
 
 		return {
 
 			// get user from storage
 			get: function() {
-				return localStorage.getObject( 'auth_token' );
+				return ngmLists.getObject( 'auth_token' );
 			},
 
 			// set user to storage
@@ -26,6 +26,7 @@ angular.module('ngmReportHub')
 				user.last_logged_in = moment();
 				user.dashboard_visits = 0;
 				localStorage.setObject( 'auth_token', user );
+				ngmLists.setObject('auth_token', user);
 				// set lists
 				if ( !user.guest ) {
 					$injector.get( 'ngmClusterLists' ).setClusterLists( user );
@@ -38,12 +39,15 @@ angular.module('ngmReportHub')
 				localStorage.removeItem( 'lists' );
 				localStorage.removeItem( 'dutyStations' );
 				localStorage.removeItem( 'auth_token' );
+				ngmLists.removeItem('lists')
+				ngmLists.removeItem('dutyStations')
+				ngmLists.removeItem('auth_token')
 			},			
 
 			// check user role
 			hasRole: function( role ) {
 				// get from storage
-				var user = localStorage.getObject( 'auth_token' );
+				var user = ngmLists.getObject( 'auth_token' );
 				// if no user
 				if ( !user ) return false; 
 				// else has role?
@@ -52,7 +56,7 @@ angular.module('ngmReportHub')
 
 			// match any role
 			hasAnyRole: function( roles ) {
-				var user = localStorage.getObject( 'auth_token' );
+				var user = ngmLists.getObject( 'auth_token' );
 				return !!user.roles.filter(function( role ) {
 					return angular.uppercase( roles ).indexOf( angular.uppercase( role ) ) >= 0;
 				}).length;

--- a/app/scripts/modules/cluster/dashboards/dashboard.cluster.js
+++ b/app/scripts/modules/cluster/dashboards/dashboard.cluster.js
@@ -21,9 +21,10 @@ angular.module('ngmReportHub')
 			'ngmData',
 			'ngmClusterHelper',
 			'ngmClusterLists',
+			'ngmLists',
 			'$translate',
 			'$filter',
-		function ( $scope, $q, $http, $location, $route, $rootScope, $window, $timeout, $filter, ngmUser, ngmAuth, ngmData, ngmClusterHelper, ngmClusterLists,$translate, $filter ) {
+		function ( $scope, $q, $http, $location, $route, $rootScope, $window, $timeout, $filter, ngmUser, ngmAuth, ngmData, ngmClusterHelper, ngmClusterLists, ngmLists, $translate, $filter ) {
 			this.awesomeThings = [
 				'HTML5 Boilerplate',
 				'AngularJS',
@@ -60,9 +61,9 @@ angular.module('ngmReportHub')
 				// lists
 				lists: {
 					clusters: ngmClusterLists.getClusters( $route.current.params.admin0pcode ).filter(cluster=>cluster.filter!==false),
-					admin1: localStorage.getObject( 'lists' ) ? localStorage.getObject( 'lists' ).admin1List : [],
-					admin2: localStorage.getObject( 'lists' ) ? localStorage.getObject( 'lists' ).admin2List : [],
-					admin3: localStorage.getObject( 'lists' ) ? localStorage.getObject( 'lists' ).admin3List : []
+					admin1: ngmLists.getObject( 'lists' ) ? ngmLists.getObject( 'lists' ).admin1List : [],
+					admin2: ngmLists.getObject( 'lists' ) ? ngmLists.getObject( 'lists' ).admin2List : [],
+					admin3: ngmLists.getObject( 'lists' ) ? ngmLists.getObject( 'lists' ).admin3List : []
 				},
 
 				// filtered data
@@ -734,6 +735,7 @@ angular.module('ngmReportHub')
 					// plus dashboard_visits
 					$scope.dashboard.user.dashboard_visits++;
 					localStorage.setObject( 'auth_token', $scope.dashboard.user );
+					ngmLists.setObject( 'auth_token', $scope.dashboard.user );
 
 					// report name
 					$scope.dashboard.report += moment().format( 'YYYY-MM-DDTHHmm' );
@@ -1206,6 +1208,7 @@ angular.module('ngmReportHub')
 
 					// set in localstorage
 					localStorage.setObject( 'lists', { admin1List: results[0].data, admin2List: results[1].data } );
+					ngmLists.setObject( 'lists', { admin1List: results[0].data, admin2List: results[1].data } );
 
 					// set dashboard
 					$scope.dashboard.init();

--- a/app/scripts/modules/cluster/reports/forms/cluster.organization.form.stock.js
+++ b/app/scripts/modules/cluster/reports/forms/cluster.organization.form.stock.js
@@ -28,9 +28,9 @@ angular.module( 'ngm.widget.organization.stock', [ 'ngm.provider' ])
     'ngmAuth',
     'ngmData',
     'ngmClusterHelper',
-    'ngmClusterLists',
+    'ngmClusterLists', 'ngmLists',
     'config','$translate',
-    function( $scope, $location, $timeout, $filter, $q, $http, $route, ngmUser, ngmAuth, ngmData, ngmClusterHelper, ngmClusterLists, config,$translate ){
+    function( $scope, $location, $timeout, $filter, $q, $http, $route, ngmUser, ngmAuth, ngmData, ngmClusterHelper, ngmClusterLists, ngmLists, config,$translate ){
       
       // project
       $scope.report = {
@@ -62,7 +62,7 @@ angular.module( 'ngm.widget.organization.stock', [ 'ngm.provider' ])
         lists: {
           clusters: ngmClusterLists.getClusters( config.organization.admin0pcode ).filter(cluster=>cluster.filter!==false),
           units: ngmClusterLists.getUnits( config.organization.admin0pcode ),
-          stocks: localStorage.getObject( 'lists' ).stockItemsList,
+          stocks: ngmLists.getObject( 'lists' ).stockItemsList,
           stock_status:[{
             stock_status_id: 'available',
             stock_status_name: 'Available'

--- a/app/scripts/modules/cluster/reports/forms/cluster.organization.form.stocks.list.js
+++ b/app/scripts/modules/cluster/reports/forms/cluster.organization.form.stocks.list.js
@@ -29,6 +29,7 @@ angular.module( 'ngm.widget.organization.stocks.list', [ 'ngm.provider' ])
     'ngmData',
     'ngmClusterHelper',
     'ngmClusterValidation',
+    'ngmLists',
     'config',
     function( $scope,
         $location,
@@ -42,6 +43,7 @@ angular.module( 'ngm.widget.organization.stocks.list', [ 'ngm.provider' ])
         ngmData,
         ngmClusterHelper,
         ngmClusterValidation,
+        ngmLists,
         config ){
 
       // project
@@ -74,11 +76,11 @@ angular.module( 'ngm.widget.organization.stocks.list', [ 'ngm.provider' ])
           warehouse: {},
           list: {
             // admin1 ( with admin0 filter at API )
-            admin1: localStorage.getObject( 'lists' ).admin1List,
+            admin1: ngmLists.getObject( 'lists' ).admin1List,
             // admin2 ( with admin0 filter at API )
-            admin2: localStorage.getObject( 'lists' ).admin2List,
+            admin2: ngmLists.getObject( 'lists' ).admin2List,
             // admin3 ( with admin0 filter at API )
-            admin3: localStorage.getObject( 'lists' ).admin3List,
+            admin3: ngmLists.getObject( 'lists' ).admin3List,
           }
         },
 

--- a/app/scripts/modules/cluster/reports/services/ngmClusterLists.js
+++ b/app/scripts/modules/cluster/reports/services/ngmClusterLists.js
@@ -11,8 +11,8 @@ angular.module( 'ngmReportHub' )
         '$http',
         '$filter',
         '$timeout',
-        'ngmAuth','$location',
-    function( $q, $http, $filter, $timeout, ngmAuth,$location ) {
+        'ngmAuth','$location', 'ngmLists',
+    function( $q, $http, $filter, $timeout, ngmAuth,$location, ngmLists ) {
 
 
 		var ngmClusterLists = {
@@ -87,12 +87,12 @@ angular.module( 'ngmReportHub' )
                                     { trainee_health_worker_id: 'environmental_health_workers', trainee_health_worker_name: 'Environmental Health Workers' }],
           
           // lists on load
-          admin1: localStorage.getObject( 'lists' ).admin1List,
-          admin2: localStorage.getObject( 'lists' ).admin2List,
-          admin3: localStorage.getObject( 'lists' ).admin3List,
-          admin4: localStorage.getObject( 'lists' ).admin4List,
-          admin5: localStorage.getObject( 'lists' ).admin5List,
-          adminSites: localStorage.getObject( 'lists' ).adminSites ? localStorage.getObject( 'lists' ).adminSites : [], // fetched on admin1 change
+          admin1: ngmLists.getObject( 'lists' ).admin1List,
+          admin2: ngmLists.getObject( 'lists' ).admin2List,
+          admin3: ngmLists.getObject( 'lists' ).admin3List,
+          admin4: ngmLists.getObject( 'lists' ).admin4List,
+          admin5: ngmLists.getObject( 'lists' ).admin5List,
+          adminSites: ngmLists.getObject( 'lists' ).adminSites ? ngmLists.getObject( 'lists' ).adminSites : [], // fetched on admin1 change
          
           // row by row filters
           admin1Select: [],
@@ -211,6 +211,7 @@ angular.module( 'ngmReportHub' )
 
           // storage
           localStorage.setObject( 'lists', lists );
+          ngmLists.setObject( 'lists', lists );
 
           // send request
           $q.all([
@@ -243,6 +244,7 @@ angular.module( 'ngmReportHub' )
 
               // storage
               localStorage.setObject( 'lists', lists );
+              ngmLists.setObject( 'lists', lists );
 
             });
         }
@@ -288,7 +290,7 @@ angular.module( 'ngmReportHub' )
           }
         } else {
           // get indicatorsList
-          var indicators = localStorage.getObject( 'lists' ).indicatorsList;
+          var indicators = ngmLists.getObject( 'lists' ).indicatorsList;
           angular.merge( indicators, { training_total_trainees: 0 } );
         }
 
@@ -681,7 +683,7 @@ angular.module( 'ngmReportHub' )
 
         // get activities list from storage
         var activities = [],
-            activitiesList = angular.copy( localStorage.getObject( 'lists' ).activitiesList );
+            activitiesList = angular.copy( ngmLists.getObject( 'lists' ).activitiesList );
 
         // no intercluster
         if ( !filterInterCluster ) {
@@ -754,11 +756,11 @@ angular.module( 'ngmReportHub' )
 
         if(admin0pcode === 'COL'){
 
-         organizations = $filter('filter')(localStorage.getObject( 'lists' ).organizationsList,
+         organizations = $filter('filter')(ngmLists.getObject( 'lists' ).organizationsList,
                  {admin0pcode: 'COL'},true );
 
         }else{
-          organizations = localStorage.getObject( 'lists' ).organizationsList
+          organizations = ngmLists.getObject( 'lists' ).organizationsList
       }
 
 
@@ -921,7 +923,7 @@ angular.module( 'ngmReportHub' )
         // get from list
           // this list needs to be updated at the db to iclude admin0pcode as string (like activities)
           // hack for NG has been put in place, so much to do, so little time (horrible, I know!)
-        donors = $filter( 'filter' )( localStorage.getObject( 'lists' ).donorsList,
+        donors = $filter( 'filter' )( ngmLists.getObject( 'lists' ).donorsList,
                           { cluster_id: cluster_id }, true );
 
         // if no list use default


### PR DESCRIPTION
use of service while navigating the app instead of hitting localStorage to speed up retrieval
the same interface as for localStorage: ngmLists.setObject, getObject, removeItem
note: localStorage is still used for use as long term storage, and still can be used to retrieve lists