### PR TITLE
feat(ui): add/use materialize-select directive

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -473,6 +473,9 @@
 		
 		<!-- REPORTING -->
 
+		<!-- DIRECTIVES -->
+		<script src="scripts/app/directives/materialize.select.js"></script>
+		
 		<!-- PROJECTS -->
 		<script src="scripts/modules/cluster/reports/controllers/cluster.project.projects.js"></script>
 		<script src="scripts/modules/cluster/reports/controllers/cluster.project.summary.js"></script>

--- a/app/scripts/app/app.js
+++ b/app/scripts/app/app.js
@@ -55,7 +55,8 @@ angular
 		'ngm.widget.list',
 		'ngm.widget.modal',
 		'ngm.widget.stats',
-		'ngm.widget.table'
+		'ngm.widget.table',
+		'ngm.materialize.select',
 	])
 	.config([ '$routeProvider', '$locationProvider', '$compileProvider','$translateProvider', function ( $routeProvider, $locationProvider, $compileProvider,$translateProvider ) {
 

--- a/app/scripts/app/directives/materialize.select.js
+++ b/app/scripts/app/directives/materialize.select.js
@@ -1,0 +1,107 @@
+angular.module("ngm.materialize.select", [])
+        .directive("materializeSelect", ["$compile", "$timeout", function ($compile, $timeout) {
+            return {
+                link: function (scope, element, attrs) {
+                    if (element.is("select")) {
+						//BugFix 139: In case of multiple enabled. Avoid the circular looping.
+                        function initSelect(newVal, oldVal) {
+                            if (attrs.multiple) {
+                                if (oldVal !== undefined && newVal !== undefined) {
+                                    if (oldVal.length === newVal.length) {
+                                        return;
+                                    }
+                                }
+                                var activeUl = element.siblings("ul.active");
+                                if (newVal !== undefined && activeUl.length) { // If select is open
+                                    var selectedOptions = activeUl.children("li.active").length; // Number of selected elements
+                                    if (selectedOptions == newVal.length) {
+                                        return;
+                                    }
+                                }
+                            }
+
+                            element.siblings(".caret").remove();
+                            // function fixActive () {         
+                            //     if (!attrs.multiple) {
+                            //         var value = element.val();
+                            //         var ul = element.siblings("ul");
+                            //         ul.find("li").each(function () {
+                            //             var that = $(this);
+                            //             if (that.text() === value) {
+                            //                 that.addClass("active");
+                            //             }
+                            //         });
+                            //     }
+                            // }
+                            scope.$evalAsync(function () {
+
+                                // TODO: test that no bugs
+                                element.material_select();
+
+                                // commented
+                                //Lines 301-311 fix Dogfalo/materialize/issues/901 and should be removed and the above uncommented whenever 901 is fixed
+                                // element.material_select(function () {
+                                //     if (!attrs.multiple) {
+                                //         element.siblings('input.select-dropdown').trigger('close');
+                                //     }
+                                //     fixActive();
+                                // });
+                                // var onMouseDown = function (e) {
+                                //     // preventing the default still allows the scroll, but blocks the blur.
+                                //     // We're inside the scrollbar if the clientX is >= the clientWidth.
+                                //     if (e.clientX >= e.target.clientWidth || e.clientY >= e.target.clientHeight) {
+                                //         e.preventDefault();
+                                //     }
+                                // };
+                                // element.siblings('input.select-dropdown').off("mousedown.material_select_fix").on('mousedown.material_select_fix', onMouseDown);
+
+                                // fixActive();
+
+                                // element.siblings('input.select-dropdown').off("click.material_select_fix").on("click.material_select_fix", function () {
+                                //     $("input.select-dropdown").not(element.siblings("input.select-dropdown")).trigger("close");
+                                // });
+                            });
+                        }
+
+
+                        // $timeout(initSelect);
+                        // run on current/next cycle $evalAsync
+                        initSelect();
+
+                        if (attrs.ngModel) {
+
+                            if (attrs.ngModel && !angular.isDefined(scope.$eval(attrs.ngModel))) {
+                                // This whole thing fixes that if initialized with undefined, then a ghost value option is inserted. If this thing wasn't done, then adding the 'watch' attribute could also fix it. #160
+                                var hasChangedFromUndefined = false;
+                                scope.$watch(attrs.ngModel, function (newVal, oldVal) {
+                                    if (!hasChangedFromUndefined && angular.isDefined(scope.$eval(attrs.ngModel))) {
+                                        hasChangedFromUndefined = true;
+                                        initSelect(); // initSelect without arguments forces it to actually run.
+                                    } else {
+                                        initSelect(newVal, oldVal);
+                                    }
+                                });
+                            } else {
+                                scope.$watch(attrs.ngModel, initSelect);
+                            }
+
+                        }
+
+                        // already watching ngModel
+                        // if ("watch" in attrs) {
+                        //     // scope.$watch(function () {
+                        //     //     return element[0].innerHTML;
+                        //     // }, function (newValue, oldValue) {
+                        //     //     if (newValue !== oldValue) {
+                        //     //         $timeout(initSelect);
+                        //     //     }
+                        //     // });
+                        // }
+                        
+                        if(attrs.ngDisabled) {
+                            scope.$watch(attrs.ngDisabled, initSelect)
+                        }
+                    }
+                }
+            };
+        }]);

--- a/app/scripts/modules/cluster/reports/forms/cluster.project.form.report.js
+++ b/app/scripts/modules/cluster/reports/forms/cluster.project.form.report.js
@@ -213,7 +213,7 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
                   // 0.50 of scrolling height, add location_limit
                   if ( ( scrollHeight - scrollPosition ) / scrollHeight < 0.50 ) {
                     // when scroll to bottom of the page
-                    $scope.project.incrementLocationLimitByOne();
+                    $scope.project.incrementLocationLimitByOneAutoSelect();
                   }
                 } else {
                   // scroll up
@@ -307,7 +307,48 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
             for (var id of ids) {
               ngmClusterBeneficiaries.updateSelectById(id);
             }
+            // required to update ng-repeat limitTo?
+            $scope.$apply();  
+          }
+        }
 
+        // if all rendered
+        if ($scope.project.report.locations.length === $scope.project.location_limit) {
+          // and all last location beneficiaries rendered
+          if ($scope.project.location_beneficiary_limit[$scope.project.location_limit - 1].beneficiary_count <= $scope.project.location_beneficiary_limit[$scope.project.location_limit - 1].beneficiary_limit) {
+            $scope.project.allRendered = true;
+          }
+        }
+      },
+
+      // incrementLocationLimit by one location if using materializeSelect directive
+      incrementLocationLimitByOneAutoSelect: function() {
+
+        var location_index = $scope.project.location_limit;
+        var last_location_index = location_index - 1;
+
+        // if not all beneficiaries on last location rendered
+        if ( $scope.project.location_beneficiary_limit[ last_location_index ].beneficiary_count > $scope.project.location_beneficiary_limit[ last_location_index ].beneficiary_limit  ) {
+          // increment
+          start = $scope.project.location_beneficiary_limit[ last_location_index ].beneficiary_limit
+          $scope.project.location_beneficiary_limit[ last_location_index ].beneficiary_limit += 6;
+
+          // required to update ng-repeat limitTo?
+          $scope.$apply();
+
+        } else {
+          // add location to render
+          if ( !$scope.project.location_beneficiary_limit[ location_index ] ) {
+            $scope.project.location_beneficiary_limit[ location_index ] = {
+              beneficiary_limit:6,
+              beneficiary_count:$scope.project.report.locations[location_index].beneficiaries.length
+            }
+          }
+
+          if ( $scope.project.report.locations.length > $scope.project.location_limit ) {
+            
+            $scope.project.location_limit += 1;
+            
             // required to update ng-repeat limitTo?
             $scope.$apply();
             
@@ -404,7 +445,7 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
 					console.log($scope.project.location_beneficiary_limit);
 					// update select
           // ngmClusterBeneficiaries.updateSelect();
-          ngmClusterBeneficiaries.updateSelectById('ngm-' + $parent + '-' + ($scope.project.report.locations[$parent].beneficiaries.length - 1));
+          // ngmClusterBeneficiaries.updateSelectById('ngm-' + $parent + '-' + ($scope.project.report.locations[$parent].beneficiaries.length - 1));
 				},
 
 				// add beneficiary
@@ -431,7 +472,7 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
 				removeBeneficiary: function() {
 					var id = $scope.project.report.locations[ $scope.project.locationIndex ].beneficiaries[ $scope.project.beneficiaryIndex ].id;
           $scope.project.report.locations[ $scope.project.locationIndex ].beneficiaries.splice( $scope.project.beneficiaryIndex, 1 );
-          ngmClusterBeneficiaries.updateSelectById('ngm-' + $scope.project.locationIndex);
+          // ngmClusterBeneficiaries.updateSelectById('ngm-' + $scope.project.locationIndex);
 					$scope.project.activePrevReportButton();
 					ngmClusterBeneficiaries.removeBeneficiary( $scope.project, id );
 				},
@@ -650,7 +691,7 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
 					if ( !$scope.project.report.locations[ $parent ].beneficiaries[ $index ].id ) {		
 					 $scope.project.report.locations[ $parent ].beneficiaries.splice( $index, 1 );
            ngmClusterBeneficiaries.form[ $parent ].splice( $index, 1 );
-           ngmClusterBeneficiaries.updateSelectById('ngm-' + $parent);
+          //  ngmClusterBeneficiaries.updateSelectById('ngm-' + $parent);
 					}
 				},
 
@@ -979,7 +1020,7 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
 									}, 400);
 								} else {
 									// reset select when edit sved report
-									ngmClusterBeneficiaries.updateSelect();
+									// ngmClusterBeneficiaries.updateSelect();
 								}
 
 							} else {

--- a/app/scripts/modules/cluster/reports/services/ngmClusterBeneficiaries.js
+++ b/app/scripts/modules/cluster/reports/services/ngmClusterBeneficiaries.js
@@ -176,11 +176,11 @@ angular.module( 'ngmReportHub' )
 						// name
 						beneficiary[ name ] = select[0][ name ];
 						// update materialize select
-						if (id) {
-							ngmClusterBeneficiaries.updateSelectById(id);
-						} else {
-							ngmClusterBeneficiaries.updateSelect();
-						}
+						// if (id) {
+						// 	ngmClusterBeneficiaries.updateSelectById(id);
+						// } else {
+						// 	ngmClusterBeneficiaries.updateSelect();
+						// }
 					}
 				}, 100 );
 			},

--- a/app/scripts/modules/cluster/views/forms/report/beneficiaries/beneficiaries.html
+++ b/app/scripts/modules/cluster/views/forms/report/beneficiaries/beneficiaries.html
@@ -73,13 +73,12 @@
 					
 					<!-- activity_type_id -->
 					<div class="input-field col s12 m6">
-						<select id="ngm-activity_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-activity_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="activity_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.activity_type_id"
 											ng-options="a_t.activity_type_id as a_t.activity_type_name for a_t in project.definition.activity_type"
-											ng-change="ngmClusterBeneficiaries.setActivity( project, $locationIndex, $beneficiaryIndex, beneficiary );
-																	ngmClusterBeneficiaries.updateSelectById(id);"
+											ng-change="ngmClusterBeneficiaries.setActivity( project, $locationIndex, $beneficiaryIndex, beneficiary );"
 											ng-disabled="project.definition.project_status === 'complete' || project.report.report_status === 'complete' || !project.definition.activity_type"
 											required>
 							<option value="">{{ 'select' | translate }}</option>
@@ -89,7 +88,7 @@
 
 					<!-- activity_description_id -->
 					<div class="input-field col s12 m6">
-						<select id="ngm-activity_description_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-activity_description_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="activity_description_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.activity_description_id"
@@ -120,13 +119,12 @@
 					
 					<!-- activity_type_id -->
 					<div class="input-field col s12 m4">
-						<select id="ngm-activity_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-activity_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="activity_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.activity_type_id"
 											ng-options="a_t.activity_type_id as a_t.activity_type_name for a_t in project.definition.activity_type"
-											ng-change="ngmClusterBeneficiaries.setActivity( project, $locationIndex, $beneficiaryIndex, beneficiary );
-																	ngmClusterBeneficiaries.updateSelectById(id);"
+											ng-change="ngmClusterBeneficiaries.setActivity( project, $locationIndex, $beneficiaryIndex, beneficiary );"
 											ng-disabled="project.definition.project_status === 'complete' || project.report.report_status === 'complete' || !project.definition.activity_type"
 											required>
 							<option value="">{{ 'select' | translate }}</option>
@@ -136,7 +134,7 @@
 
 					<!-- activity_description_id -->
 					<div class="input-field col s12 m4">
-						<select id="ngm-activity_description_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-activity_description_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="activity_description_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.activity_description_id"
@@ -159,7 +157,7 @@
 
 					<!-- activity_detail_id -->
 					<div class="input-field col s4">
-						<select id="ngm-activity_detail_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-activity_detail_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="activity_detail_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.activity_detail_id"
@@ -188,13 +186,12 @@
 					
 					<!-- activity_type_id -->
 					<div class="input-field col s12 m4">
-						<select id="ngm-activity_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-activity_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="activity_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.activity_type_id"
 											ng-options="a_t.activity_type_id as a_t.activity_type_name for a_t in project.definition.activity_type"
-											ng-change="ngmClusterBeneficiaries.setActivity( project, $locationIndex, $beneficiaryIndex, beneficiary );
-																	ngmClusterBeneficiaries.updateSelectById(id);"
+											ng-change="ngmClusterBeneficiaries.setActivity( project, $locationIndex, $beneficiaryIndex, beneficiary );"
 											ng-disabled="project.definition.project_status === 'complete' || project.report.report_status === 'complete' || !project.definition.activity_type"
 											required>
 							<option value="">{{ 'select' | translate }}</option>
@@ -204,7 +201,7 @@
 
 					<!-- activity_description_id -->
 					<div class="input-field col s12 m4">
-						<select id="ngm-activity_description_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-activity_description_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="activity_description_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.activity_description_id"
@@ -227,7 +224,7 @@
 
 					<!-- injury_treatment_same_province -->
 					<div class="input-field col s4">
-						<select id="ngm-injury_treatment_same_province-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-injury_treatment_same_province-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="injury_treatment_same_province-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.injury_treatment_same_province"
@@ -251,7 +248,7 @@
 
 					<!-- indicator_id -->
 					<div class="input-field col s12">
-						<select id="ngm-indicator_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-indicator_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="indicator_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.indicator_id"
@@ -262,8 +259,7 @@
 																				activity_description_id: beneficiary.activity_description_id,
 																				activity_detail_id: beneficiary.activity_detail_id 
 																		} : true"
-											ng-change="ngmClusterBeneficiaries.setBeneficiaries( project, 'indicator', $locationIndex, $beneficiaryIndex, beneficiary );
-																	ngmClusterBeneficiaries.updateSelectById(id);"
+											ng-change="ngmClusterBeneficiaries.setBeneficiaries( project, 'indicator', $locationIndex, $beneficiaryIndex, beneficiary );"
 											ng-disabled="project.definition.project_status === 'complete' || project.report.report_status === 'complete' || !beneficiary.activity_type_id"
 											required>
 							<option value="">{{ 'select' | translate }}</option>
@@ -283,7 +279,7 @@
 
 					<!-- beneficiary_type -->
 					<div class="input-field col s12">
-						<select id="ngm-beneficiary_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-beneficiary_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="beneficiary_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.beneficiary_type_id"
@@ -307,7 +303,7 @@
 
 					<!-- beneficiary_type -->
 					<div class="input-field col s6">
-						<select id="ngm-beneficiary_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-beneficiary_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="beneficiary_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.beneficiary_type_id"
@@ -324,7 +320,7 @@
 
 					<!-- delivery_type_id -->
 					<div class="input-field col s6">
-						<select id="ngm-delivery_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-delivery_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="delivery_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.delivery_type_id"
@@ -345,7 +341,7 @@
 
 					<!-- beneficiary_type -->
 					<div class="input-field col s12 m4">
-						<select id="ngm-beneficiary_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-beneficiary_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="beneficiary_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.beneficiary_type_id"
@@ -363,7 +359,7 @@
 					
 					<!-- beneficiary_type -->
 					<div class="input-field col s12 m4">
-						<select id="ngm-beneficiary_category_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-beneficiary_category_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="beneficiary_category_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.beneficiary_category_id"
@@ -377,13 +373,13 @@
 
 					<!-- delivery_type_id -->
 					<div class="input-field col s4">
-						<select id="ngm-delivery_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-delivery_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="delivery_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.delivery_type_id"
 											ng-change="ngmClusterBeneficiaries.updateName( project.lists.delivery_types, 'delivery_type_id', 'delivery_type_name', beneficiary, id )"
 											ng-options="b.delivery_type_id as b.delivery_type_name for b in project.lists.delivery_types"
-											ng-disabled="project.definition.project_status === 'complete' || project.report.report_status === 'complete' || !beneficiary.beneficiary_type_id">
+											ng-disabled="project.definition.project_status === 'complete' || project.report.report_status === 'complete' || !beneficiary.beneficiary_type_id" materialize-select>
 							<option value="">{{ 'select' | translate }}</option>
 						</select>
 						<label for="ngm-delivery_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" class="active" style="transform:translateY(-10%)">{{ 'type' | translate }}</label>
@@ -404,7 +400,7 @@
 
 					<!-- mpc_delivery_type_id -->
 					<div class="input-field col s12 m4">
-						<select id="ngm-mpc_delivery_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-mpc_delivery_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="mpc_delivery_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.mpc_delivery_type_id"
@@ -419,7 +415,7 @@
 
 					<!-- mpc_mechanism_type_id -->
 					<div class="input-field col s12 m4">
-						<select id="ngm-mpc_mechanism_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-mpc_mechanism_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="mpc_mechanism_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.mpc_mechanism_type_id"
@@ -434,7 +430,7 @@
 
 					<!-- transfer_type_id -->
 					<div class="input-field col s12 m4">
-						<select id="ngm-transfer_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-transfer_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="transfer_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.transfer_type_id"
@@ -459,7 +455,7 @@
 
 					<!-- mpc_delivery_type_id -->
 					<div class="input-field col s12 m4">
-						<select id="ngm-mpc_delivery_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-mpc_delivery_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="mpc_delivery_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.mpc_delivery_type_id"
@@ -474,7 +470,7 @@
 
 					<!-- mpc_mechanism_type_id -->
 					<div class="input-field col s12 m4">
-						<select id="ngm-mpc_mechanism_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-mpc_mechanism_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="mpc_mechanism_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.mpc_mechanism_type_id"
@@ -489,7 +485,7 @@
 
 					<!-- package_type_id -->
 					<div class="input-field col s12 m4">
-						<select id="ngm-package_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-package_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="package_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.package_type_id"
@@ -521,7 +517,7 @@
 
 					<!-- mpc_delivery_type_id -->
 					<div class="input-field col s12 m3">
-						<select id="ngm-mpc_delivery_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-mpc_delivery_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="mpc_delivery_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.mpc_delivery_type_id"
@@ -536,7 +532,7 @@
 
 					<!-- mpc_mechanism_type_id -->
 					<div class="input-field col s12 m3">
-						<select id="ngm-mpc_mechanism_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-mpc_mechanism_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="mpc_mechanism_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.mpc_mechanism_type_id"
@@ -551,7 +547,7 @@
 
 					<!-- transfer_type_id -->
 					<div class="input-field col s12 m3">
-						<select id="ngm-transfer_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-transfer_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="transfer_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.transfer_type_id"
@@ -565,7 +561,7 @@
 
 					<!-- package_type_id -->
 					<div class="input-field col s12 m3">
-						<select id="ngm-package_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-package_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="package_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.package_type_id"
@@ -600,7 +596,7 @@
 												!ngmClusterBeneficiaries.form[ $locationIndex ][ $beneficiaryIndex ][ 'transfer_type_id' ] )">
 					<!-- unit_type_id -->
 					<div class="input-field col s6">
-						<select id="ngm-unit_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
+						<select materialize-select id="ngm-unit_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}" 
 											name="unit_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											class="validate"
 											ng-model="beneficiary.unit_type_id"


### PR DESCRIPTION
Proposal for usage materialize-select directive:

re/initialization on directive itself, no need for manual update select with indexes, watch over ngModel
usage <select materialize-select ... 
modified originally used materialSelect directive from angular-materialize

Notes: tested on default AF, commented all used updateSelect functions
added in all selects in modules\cluster\views\forms\report\beneficiaries\beneficiaries.html
TODO: code clean up, test, to check how affects other countries