### PR TITLE
fix: role that show in profile page

### DIFF
--- a/app/scripts/app/controllers/admin/controller.authentication.js
+++ b/app/scripts/app/controllers/admin/controller.authentication.js
@@ -49,7 +49,7 @@ angular.module('ngm.widget.form.authentication', ['ngm.provider'])
 
 				date : new Date(),
 
-				user: ngmUser.get() ? ngmUser.get() : {},
+				user: config.user ? config.user : ngmUser.get(),//ngmUser.get() ? ngmUser.get() : {},
 
 				btnDisabled: false,
 


### PR DESCRIPTION
The role that appears in the profile page, always the role of the user account that we used to log in. Not the user that we open