### PR TITLE
feature(activities): filter by active date

### DIFF
--- a/app/scripts/modules/cluster/reports/forms/cluster.project.form.details.js
+++ b/app/scripts/modules/cluster/reports/forms/cluster.project.form.details.js
@@ -168,7 +168,7 @@ angular.module( 'ngm.widget.project.details', [ 'ngm.provider' ])
 				},
 
 				// lists ( project, mpc transfers )
-				lists: ngmClusterLists.setLists( config.project, 30 ),
+				lists: ngmClusterLists.setLists( config.project, config.project.project_start_date, config.project.project_end_date, 30 ),
 
 				// datepicker
 				datepicker: {
@@ -180,7 +180,12 @@ angular.module( 'ngm.widget.project.details', [ 'ngm.provider' ])
 								moment( new Date( $scope.project.definition.project_end_date ) ).format('YYYY-MM-DD');
 
 						// get strategic objectives
-							$scope.project.checkStrategicObjectiveYear()
+						$scope.project.checkStrategicObjectiveYear();
+
+						// update lists
+						$timeout(function () {
+							$scope.project.lists = ngmClusterLists.setLists(config.project, $scope.project.definition.project_start_date, $scope.project.definition.project_end_date, 30);
+						}, 0)
 					}
 				},
 

--- a/app/scripts/modules/cluster/reports/forms/cluster.project.form.report.js
+++ b/app/scripts/modules/cluster/reports/forms/cluster.project.form.report.js
@@ -118,7 +118,7 @@ angular.module( 'ngm.widget.project.report', [ 'ngm.provider' ])
 													|| moment.utc(config.project.project_end_date).endOf('month') < moment.utc(config.report.reporting_period).startOf('month'),
 
 				// lists ( project, mpc transfers )
-				lists: ngmClusterLists.setLists( config.project, 10 ),
+				lists: ngmClusterLists.setLists( config.project, moment(config.report.reporting_period).startOf('month'), moment(config.report.reporting_period).endOf('month'), 10 ),
 
 
 				/**** TEMPLATES ****/

--- a/app/scripts/modules/cluster/reports/services/ngmClusterBeneficiaries.js
+++ b/app/scripts/modules/cluster/reports/services/ngmClusterBeneficiaries.js
@@ -6,6 +6,20 @@
  *
  */
 angular.module( 'ngmReportHub' )
+	// filter activity by active date
+	.filter('filterActiveDate', [ '$filter', function ( $filter ) {
+		return function (data, list) {
+			if (data) {
+				let newData = data.filter(function (d) {
+					let isActive = list.filter(function (a) {
+						return a.cluster_id === d.cluster_id && a.activity_type_id === d.activity_type_id;
+					});
+					return isActive.length;
+				})
+				return newData;
+			}
+		}
+	}])
 	// filter active type
 	.filter('filterActiveTypes', [ '$filter', function ( $filter ) {
 		return function( data, beneficiary ) {
@@ -549,9 +563,9 @@ angular.module( 'ngmReportHub' )
  					ngmClusterBeneficiaries.form[$parent][$index].display = ngmClusterBeneficiaries.showFormInputs( beneficiary, ngmClusterBeneficiaries.form[$parent][$index] );
 				}
 
-				// if beneficiary.response exist then check ngmClusterBeneficiaries.form[$parent][$index]['exist'] 
+				// if beneficiary.response exist then check ngmClusterBeneficiaries.form[$parent][$index]['exist']
 				if (beneficiary.response && beneficiary.response.length>0){
-					
+
 					if (!ngmClusterBeneficiaries.form[$parent][$index]['response']){
 						temp_list = []
 					}else{

--- a/app/scripts/modules/cluster/views/forms/report/beneficiaries/beneficiaries.html
+++ b/app/scripts/modules/cluster/views/forms/report/beneficiaries/beneficiaries.html
@@ -220,7 +220,7 @@
 											ng-model="beneficiary.activity_type_id"
 											ng-options="a_t.activity_type_id as a_t.activity_type_name
 																		for a_t in project.definition.activity_type |
-																		filterActiveTypes:beneficiary"
+																		filterActiveTypes:beneficiary | filterActiveDate: project.lists.activity_types"
 											ng-change="ngmClusterBeneficiaries.setActivity( project, $locationIndex, $beneficiaryIndex, beneficiary );
 											ngmClusterBeneficiaries.inputChange( 'ngm-activity_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}' );"
 											ng-disabled="project.definition.project_status === 'complete' || project.report.report_status === 'complete' || !project.definition.activity_type"
@@ -272,7 +272,7 @@
 											ng-model="beneficiary.activity_type_id"
 											ng-options="a_t.activity_type_id as a_t.activity_type_name
 																		for a_t in project.definition.activity_type |
-																		filterActiveTypes:beneficiary"
+																		filterActiveTypes:beneficiary | filterActiveDate: project.lists.activity_types"
 											ng-change="ngmClusterBeneficiaries.setActivity( project, $locationIndex, $beneficiaryIndex, beneficiary );
 												ngmClusterBeneficiaries.inputChange( 'ngm-activity_type_id-{{ $locationIndex }}-{{ $beneficiaryIndex }}' );"
 											ng-disabled="project.definition.project_status === 'complete' ||


### PR DESCRIPTION
adding support for filtering activities by start_date, end_date by reporting period (project dates, report dates)
- activities configuration fields start_date, end_date in the format "YYYY-MM-DD"
- check for start_date or end_date is skipped if empty
- adding parameters for setLists: start_date, end_date; for project project_start_date, project_end_date, for report reporting_period, reporting_period end of month; on project dates change setLists runs
- adding an additional filter on activity types for beneficiaries to filter out types not active in that period
notes:
- activity active functionality is not changed and could be also used, solving the case when record id is present, and inactive activities should not be shown
- assuming if partners change project dates they haven't used activities which won't be active on new dates otherwise they will need to delete it as they should not be used
 - different activity configuration for different reporting periods could be used but on target beneficiaries first is used if multiple in project dates
