### PR TITLE
Implementing infinite scroll to reduce rendering time on Project Plan page

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -922,6 +922,7 @@
 		<script src="bower_components/highcharts-ng/dist/highcharts-ng.js"></script>
 		<script src="bower_components/leaflet.markercluster/dist/leaflet.markercluster-src.js"></script>
 		<script src="bower_components/materialize/bin/materialize.js"></script>
+		<script src="bower_components/ngInfiniteScroll/build/ng-infinite-scroll.min.js"></script>
 		<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.js"></script> -->
 		<script src="bower_components/moment/moment.js"></script>
 		<script src="bower_components/ngm-dashboard-framework/dist/ngm-dashboard-framework.js"></script>

--- a/app/scripts/app/app.js
+++ b/app/scripts/app/app.js
@@ -25,6 +25,7 @@ angular
 		'highcharts-ng',
 		'leaflet-directive',
 		'xeditable',
+		'infinite-scroll',
 		// ngm
 		'ngm',
 		'ngm.widget.form.authentication',

--- a/app/scripts/modules/cluster/reports/forms/cluster.project.form.details.js
+++ b/app/scripts/modules/cluster/reports/forms/cluster.project.form.details.js
@@ -87,6 +87,14 @@ angular.module( 'ngm.widget.project.details', [ 'ngm.provider' ])
 			$scope.messageFromfile = {project_detail_message :[],target_beneficiaries_message:[],target_locations_message:[]};
 			$scope.inputString = false;
 
+			//Infinite scroll implementation for locations
+			const LOCATION_COUNT = 10;
+			$scope.count = LOCATION_COUNT;
+			$scope.start = 0;
+			$scope.end = LOCATION_COUNT;
+			$scope.paginated_target_locations= [],
+			$scope.isLoading = false;
+
 			// project
 			$scope.project = {
 
@@ -246,6 +254,8 @@ angular.module( 'ngm.widget.project.details', [ 'ngm.provider' ])
 					ngmClusterBeneficiaries.setBeneficiariesForm( $scope.project.lists, 0, $scope.project.definition.target_beneficiaries );
 					// set form inputs
 					ngmCbLocations.setLocationsForm( $scope.project, $scope.project.definition.target_locations );
+					// Set limited amount of locations
+					$scope.paginated_target_locations = $scope.project.definition.target_locations.slice($scope.start, $scope.end);
 					// set admin1,2,3,4,5 && site_type && site_implementation
 					ngmClusterLocations.setLocationAdminSelect($scope.project, $scope.project.definition.target_locations);
 					// documents uploads
@@ -330,7 +340,19 @@ angular.module( 'ngm.widget.project.details', [ 'ngm.provider' ])
 
 
 				},
-
+				// Push objects, in chunk of 10s to the location array to make rendering easy
+				addMoreItems: function(){
+					$scope.start = $scope.end;
+					$scope.end += $scope.count;
+					var paginated = $scope.project.definition.target_locations.slice($scope.start, $scope.end);
+					setTimeout(function(){
+						paginated.forEach(function (loc, index) {
+							$scope.paginated_target_locations.push(loc);
+						});
+					},100);
+					// Control loading notification
+					$scope.isLoading = $scope.end >= $scope.project.definition.target_locations.length - 1 ? false : true;
+				},
 				// cofirm exit if changes
 				modalConfirm: function( modal ){
 					if( modal === 'summary-modal' ) {

--- a/app/scripts/modules/cluster/views/forms/details/target-locations/locations.html
+++ b/app/scripts/modules/cluster/views/forms/details/target-locations/locations.html
@@ -69,7 +69,8 @@
 					<div class="row">
 						<div class="col s12 card">
 							<div style="padding-top: 10px; padding-left: 40px;">
-							  <table class="bordered responsive-table" ng-show="project.definition.target_locations.length">
+							  <table infinite-scroll='project.addMoreItems()' infinite-scroll-distance='1' class="bordered responsive-table"
+							  	ng-show="project.definition.target_locations.length">
 							    <tr style="font-weight: 400">
 							    	<td></td>
 							    	<td>{{'reporter' | translate}}</td>
@@ -87,7 +88,7 @@
 										<td ng-if="project.definition.implementing_partners_checked">{{'partner'|translate}}</td>
 							      <td ng-show="project.definition.project_status !== 'complete'">{{'edit'|translate}}</td>
 							    </tr>
-							    <tr ng-repeat="location in project.definition.target_locations | orderBy:'createdAt' track by $index" dir="ltr">
+							    <tr ng-repeat="location in paginated_target_locations | orderBy:'createdAt' track by location.id" dir="ltr">
 							    	<td>
 							    		<i class="material-icons" style="color: teal;">person_pin</i>
 							    	</td>
@@ -306,7 +307,11 @@
 							          </button>
 							        </div>
 							      </td>
-							    </tr>
+								</tr>
+								<tr>
+									<td ng-if="isLoading" colspan="15" style="text-align: center" class="text-bold"><strong>Loading More Locations...</strong></td>
+								</tr>
+
 							  </table>
 
 							  <!-- default -->

--- a/app/scripts/modules/cluster/views/forms/report/beneficiaries/beneficiaries.html
+++ b/app/scripts/modules/cluster/views/forms/report/beneficiaries/beneficiaries.html
@@ -1569,7 +1569,7 @@
 						</div>
 
 						<!-- elderly_men -->
-						<div class="input-field col s12 m3 l2">
+						<div class="input-field col s12 m3">
 							<input id="ngm-elderly_men-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											name="ngm-elderly_men-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											type="number"
@@ -1637,7 +1637,7 @@
 						</div>
 
 						<!-- elderly_women -->
-						<div class="input-field col s12 m3 l2">
+						<div class="input-field col s12 m3">
 							<input id="ngm-elderly_women-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											name="ngm-elderly_women-{{ $locationIndex }}-{{ $beneficiaryIndex }}"
 											type="number"

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,8 @@
     "angular-xeditable": "^0.6.0",
     "angular-translate": "^2.18.1",
     "angular-material": "1.1.18",
-    "angular-aria": "1.4.8"
+    "angular-aria": "1.4.8",
+    "ngInfiniteScroll": "^1.3.4"
   },
   "devDependencies": {
     "angular-mocks": "1.4.8",


### PR DESCRIPTION
**The Issue:**
The "Project Plan" page, in some cases, has trouble loading large array of locations. This is because Angularjs tries to render all these objects at once, hence causing a huge drag in performance and user experience.  Please see: https://reporthub.org/desk/#/cluster/projects/details/5e57a2533b148c5a4754ecd0


**The Proposal:**
A great way to improve performance on the page is to render 'only the visible' objects from the array at any time (aka Lazy loading). Instead of iterating directly through `$scope.project.definition.target_locations`, which can have large number of locations, we can iterate through a new array `$scope.paginated_target_locations`, which initially contains the first 10 objects of `$scope.project.definition.target_locations`. The infinite scroll then calls the `addMoreItems()` function to scoop the next 10 objects from `$scope.project.definition.target_locations` and pushes them into `$scope.paginated_target_locations`. 

**Requirements**
Run `bower install ngInfiniteScroll`
